### PR TITLE
Added support for key tag

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -77,6 +77,7 @@ impl<T:Iterator<Item=ParserResult<PlistEvent>>> Builder<T> {
 			Some(PlistEvent::IntegerValue(i)) => Ok(Plist::Integer(i)),
 			Some(PlistEvent::RealValue(f)) => Ok(Plist::Real(f)),
 			Some(PlistEvent::StringValue(s)) => Ok(Plist::String(s)),
+			Some(PlistEvent::KeyValue(s)) => Ok(Plist::Key(s)),
 
 			Some(PlistEvent::EndArray) => Err(BuilderError::InvalidEvent),
 			Some(PlistEvent::EndDictionary) => Err(BuilderError::InvalidEvent),
@@ -86,7 +87,7 @@ impl<T:Iterator<Item=ParserResult<PlistEvent>>> Builder<T> {
 		}
 	}
 
-	fn build_array(&mut self, len: Option<u64>) -> Result<Vec<Plist>, BuilderError> {	
+	fn build_array(&mut self, len: Option<u64>) -> Result<Vec<Plist>, BuilderError> {
 		let mut values = match len {
 			Some(len) => Vec::with_capacity(len as usize),
 			None => Vec::new()
@@ -109,7 +110,7 @@ impl<T:Iterator<Item=ParserResult<PlistEvent>>> Builder<T> {
 			try!(self.bump());
 			match self.token.take() {
 				Some(PlistEvent::EndDictionary) => return Ok(values),
-				Some(PlistEvent::StringValue(s)) => {
+				Some(PlistEvent::StringValue(s)) | Some(PlistEvent::KeyValue(s)) => {
 					try!(self.bump());
 					values.insert(s, try!(self.build_value()));
 				},
@@ -138,16 +139,16 @@ mod tests {
 		let events = vec![
 			StartPlist,
 			StartDictionary(None),
-			StringValue("Author".to_owned()),
+			KeyValue("Author".to_owned()),
 			StringValue("William Shakespeare".to_owned()),
-			StringValue("Lines".to_owned()),
+			KeyValue("Lines".to_owned()),
 			StartArray(None),
 			StringValue("It is a tale told by an idiot,".to_owned()),
 			StringValue("Full of sound and fury, signifying nothing.".to_owned()),
 			EndArray,
-			StringValue("Birthdate".to_owned()),
+			KeyValue("Birthdate".to_owned()),
 			IntegerValue(1564),
-			StringValue("Height".to_owned()),
+			KeyValue("Height".to_owned()),
 			RealValue(1.60),
 			EndDictionary,
 			EndPlist,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,10 @@ pub enum Plist {
 	Date(DateTime<UTC>),
 	Real(f64),
 	Integer(i64),
-	String(String)
+	String(String),
+	Key(String)
 }
-		
+
 use rustc_serialize::base64::{STANDARD, ToBase64};
 use rustc_serialize::json::Json as RustcJson;
 
@@ -41,6 +42,7 @@ impl Plist {
 			Plist::Real(value) => RustcJson::F64(value),
 			Plist::Integer(value) => RustcJson::I64(value),
 			Plist::String(value) => RustcJson::String(value),
+			Plist::Key(value) => RustcJson::String(value),
 		}
 	}
 }
@@ -62,6 +64,7 @@ pub enum PlistEvent {
 	IntegerValue(i64),
 	RealValue(f64),
 	StringValue(String),
+	KeyValue(String),
 }
 
 pub type ParserResult<T> = Result<T, ParserError>;

--- a/src/xml/reader.rs
+++ b/src/xml/reader.rs
@@ -57,12 +57,12 @@ impl<R: Read> StreamingParser<R> {
 				XmlEvent::StartElement { name, .. } => {
 					// Add the current element to the element stack
 					self.element_stack.push(name.local_name.clone());
-					
+
 					match &name.local_name[..] {
 						"plist" => return Some(Ok(PlistEvent::StartPlist)),
 						"array" => return Some(Ok(PlistEvent::StartArray(None))),
 						"dict" => return Some(Ok(PlistEvent::StartDictionary(None))),
-						"key" => return Some(self.read_content(|s| Ok(PlistEvent::StringValue(s)))),
+						"key" => return Some(self.read_content(|s| Ok(PlistEvent::KeyValue(s)))),
 						"true" => return Some(Ok(PlistEvent::BooleanValue(true))),
 						"false" => return Some(Ok(PlistEvent::BooleanValue(false))),
 						"data" => return Some(self.read_content(|s| {
@@ -162,22 +162,22 @@ mod tests {
 		let comparison = &[
 			StartPlist,
 			StartDictionary(None),
-			StringValue("Author".to_owned()),
+			KeyValue("Author".to_owned()),
 			StringValue("William Shakespeare".to_owned()),
-			StringValue("Lines".to_owned()),
+			KeyValue("Lines".to_owned()),
 			StartArray(None),
 			StringValue("It is a tale told by an idiot,".to_owned()),
 			StringValue("Full of sound and fury, signifying nothing.".to_owned()),
 			EndArray,
-			StringValue("Death".to_owned()),
+			KeyValue("Death".to_owned()),
 			IntegerValue(1564),
-			StringValue("Height".to_owned()),
+			KeyValue("Height".to_owned()),
 			RealValue(1.60),
-			StringValue("Data".to_owned()),
+			KeyValue("Data".to_owned()),
 			DataValue(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
-			StringValue("Birthdate".to_owned()),
+			KeyValue("Birthdate".to_owned()),
 			DateValue(UTC.ymd(1981, 05, 16).and_hms(11, 32, 06)),
-			StringValue("Blank".to_owned()),
+			KeyValue("Blank".to_owned()),
 			StringValue("".to_owned()),
 			EndDictionary,
 			EndPlist

--- a/src/xml/writer.rs
+++ b/src/xml/writer.rs
@@ -115,6 +115,7 @@ impl<W: Write> Writer<W> {
 			PlistEvent::IntegerValue(ref value) => try!(self.write_element_and_value("integer", &value.to_string())),
 			PlistEvent::RealValue(ref value) => try!(self.write_element_and_value("real", &value.to_string())),
 			PlistEvent::StringValue(ref value) => try!(self.write_element_and_value("string", &*value)),
+			PlistEvent::KeyValue(ref value) => try!(self.write_element_and_value("key", &*value)),
 		})
 	}
 }
@@ -136,20 +137,20 @@ mod tests {
 		let plist = &[
 			StartPlist,
 			StartDictionary(None),
-			StringValue("Author".to_owned()),
+			KeyValue("Author".to_owned()),
 			StringValue("William Shakespeare".to_owned()),
-			StringValue("Lines".to_owned()),
+			KeyValue("Lines".to_owned()),
 			StartArray(None),
 			StringValue("It is a tale told by an idiot,".to_owned()),
 			StringValue("Full of sound and fury, signifying nothing.".to_owned()),
 			EndArray,
-			StringValue("Death".to_owned()),
+			KeyValue("Death".to_owned()),
 			IntegerValue(1564),
-			StringValue("Height".to_owned()),
+			KeyValue("Height".to_owned()),
 			RealValue(1.60),
-			StringValue("Data".to_owned()),
+			KeyValue("Data".to_owned()),
 			DataValue(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
-			StringValue("Birthdate".to_owned()),
+			KeyValue("Birthdate".to_owned()),
 			DateValue(UTC.ymd(1981, 05, 16).and_hms(11, 32, 06)),
 			EndDictionary,
 			EndPlist
@@ -166,18 +167,18 @@ mod tests {
 		}
 
 		let comparison = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<plist version=\"1.0\"><dict><string>Author</string>
+<plist version=\"1.0\"><dict><key>Author</key>
 <string>William Shakespeare</string>
-<string>Lines</string>
+<key>Lines</key>
 <array><string>It is a tale told by an idiot,</string>
 <string>Full of sound and fury, signifying nothing.</string></array>
-<string>Death</string>
+<key>Death</key>
 <integer>1564</integer>
-<string>Height</string>
+<key>Height</key>
 <real>1.6</real>
-<string>Data</string>
+<key>Data</key>
 <data>AAAAvgAAAAMAAAAeAAAA</data>
-<string>Birthdate</string>
+<key>Birthdate</key>
 <date>1981-05-16T11:32:06+00:00</date></dict></plist>";
 
 


### PR DESCRIPTION
I'd like to propose `key ` tag support. Most plist files, at least those used by Apple, use `key` tag instead of simple `string` extensively. When you're working with e.g. iOS plists this feature is a must have.

What do you think?