### PR TITLE
Upgrade chrono from 0.3 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["serde"]
 [dependencies]
 base64 = "0.5.1"
 byteorder = "1.0.0"
-chrono = "0.3.0"
+chrono = "0.4.0"
 xml-rs = "0.4.1"
 serde = { version = "1.0.2", optional = true }
 

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -320,7 +320,7 @@ impl<R: Read + Seek> Iterator for EventReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, UTC};
+    use chrono::{TimeZone, Utc};
     use std::fs::File;
     use std::path::Path;
 
@@ -346,7 +346,7 @@ mod tests {
                            StringValue("Height".to_owned()),
                            RealValue(1.60),
                            StringValue("Birthdate".to_owned()),
-                           DateValue(UTC.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
+                           DateValue(Utc.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
                            StringValue("Author".to_owned()),
                            StringValue("William Shakespeare".to_owned()),
                            StringValue("Data".to_owned()),

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Duration, TimeZone, UTC};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use std::fmt;
 use std::str::FromStr;
 
@@ -7,7 +7,7 @@ use {Error, Result};
 /// A UTC timestamp. Used for serialization to and from the plist date type.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Date {
-    inner: DateTime<UTC>,
+    inner: DateTime<Utc>,
 }
 
 impl Date {
@@ -32,21 +32,21 @@ impl Date {
         let dur = Duration::milliseconds(whole_millis as i64);
         let dur = dur + Duration::nanoseconds(submilli_nanos as i64);
 
-        let plist_epoch = UTC.ymd(2001, 1, 1).and_hms(0, 0, 0);
+        let plist_epoch = Utc.ymd(2001, 1, 1).and_hms(0, 0, 0);
         let date = plist_epoch.checked_add_signed(dur).ok_or(Error::InvalidData)?;
 
         Ok(Date { inner: date })
     }
 }
 
-impl From<DateTime<UTC>> for Date {
-    fn from(date: DateTime<UTC>) -> Self {
+impl From<DateTime<Utc>> for Date {
+    fn from(date: DateTime<Utc>) -> Self {
         Date { inner: date }
     }
 }
 
-impl Into<DateTime<UTC>> for Date {
-    fn into(self) -> DateTime<UTC> {
+impl Into<DateTime<Utc>> for Date {
+    fn into(self) -> DateTime<Utc> {
         self.inner
     }
 }
@@ -62,7 +62,7 @@ impl FromStr for Date {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         let date = DateTime::parse_from_rfc3339(s).map_err(|_| ())?;
-        Ok(Date { inner: date.with_timezone(&UTC) })
+        Ok(Date { inner: date.with_timezone(&Utc) })
     }
 }
 

--- a/src/plist.rs
+++ b/src/plist.rs
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn test_plist_access() {
         use std::collections::BTreeMap;
-        use chrono::*;
+        use chrono::prelude::*;
         use super::Date;
 
         let vec = vec![Plist::Real(0.0)];
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(Plist::Data(slice.to_vec()).into_data(),
                    Some(slice.to_vec()));
 
-        let date: Date = UTC::now().into();
+        let date: Date = Utc::now().into();
         assert_eq!(Plist::Date(date.clone()).as_date(), Some(&date));
 
         assert_eq!(Plist::Real(0.0).as_real(), Some(0.0));

--- a/src/xml/reader.rs
+++ b/src/xml/reader.rs
@@ -146,7 +146,7 @@ impl<R: Read> Iterator for EventReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, UTC};
+    use chrono::{TimeZone, Utc};
     use std::fs::File;
     use std::path::Path;
 
@@ -176,7 +176,7 @@ mod tests {
                            StringValue("Data".to_owned()),
                            DataValue(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
                            StringValue("Birthdate".to_owned()),
-                           DateValue(UTC.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
+                           DateValue(Utc.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
                            StringValue("Blank".to_owned()),
                            StringValue("".to_owned()),
                            EndDictionary];

--- a/src/xml/writer.rs
+++ b/src/xml/writer.rs
@@ -187,7 +187,7 @@ impl<W: Write> PlistEventWriter for EventWriter<W> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, UTC};
+    use chrono::{TimeZone, Utc};
     use std::io::Cursor;
 
     use super::*;
@@ -211,7 +211,7 @@ mod tests {
                       StringValue("Data".to_owned()),
                       DataValue(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
                       StringValue("Birthdate".to_owned()),
-                      DateValue(UTC.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
+                      DateValue(Utc.ymd(1981, 05, 16).and_hms(11, 32, 06).into()),
                       EndDictionary];
 
         let mut cursor = Cursor::new(Vec::new());

--- a/tests/serde_tests/mod.rs
+++ b/tests/serde_tests/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeZone, UTC};
+use chrono::{TimeZone, Utc};
 use plist::{Date, EventWriter, PlistEvent, Result as PlistResult};
 use plist::serde::{Serializer, Deserializer};
 use plist::PlistEvent::*;
@@ -247,7 +247,7 @@ struct TypeWithDate {
 
 #[test]
 fn type_with_date() {
-    let date: Date = UTC.ymd(1981, 05, 16).and_hms(11, 32, 06).into();
+    let date: Date = Utc.ymd(1981, 05, 16).and_hms(11, 32, 06).into();
 
     let obj = TypeWithDate {
         a: Some(28),


### PR DESCRIPTION
Makes downstreams have one less dependency if they use other crates whose chrono dependency is at 0.4 as well.