### PR TITLE
Update xml-rs to 0.8.0, reimplement plist prologue output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["serde"]
 base64 = "0.9.0"
 byteorder = "1.1.0"
 humantime = "1.1.1"
-xml-rs = "0.7.0"
+xml-rs = "0.8.0"
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]

--- a/src/xml/writer.rs
+++ b/src/xml/writer.rs
@@ -213,6 +213,8 @@ mod tests {
             DataValue(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
             StringValue("Birthdate".to_owned()),
             DateValue(parse_rfc3339_weak("1981-05-16 11:32:06").unwrap().into()),
+            StringValue("Comment".to_owned()),
+            StringValue("2 < 3".to_owned()), // make sure characters are escaped
             EndDictionary,
         ];
 
@@ -245,6 +247,8 @@ mod tests {
 \t<data>AAAAvgAAAAMAAAAeAAAA</data>
 \t<key>Birthdate</key>
 \t<date>1981-05-16T11:32:06Z</date>
+\t<key>Comment</key>
+\t<string>2 &lt; 3</string>
 </dict>
 </plist>";
 


### PR DESCRIPTION
This reimplements #27 using xml-rs 0.8.0's new `inner_mut()` method. This lets us keep character escaping enabled, which should be safer for future maintenance.