### PR TITLE
Add XmlWriter.into_inner()

### DIFF
--- a/src/events/xml_writer.rs
+++ b/src/events/xml_writer.rs
@@ -89,6 +89,10 @@ impl<W: Write> XmlWriter<W> {
     pub fn write(&mut self, event: &Event) -> Result<(), Error> {
         <Self as Writer>::write(self, event)
     }
+    
+    pub fn into_inner(self) -> W {
+        self.xml_writer.into_inner()
+    }
 }
 
 impl<W: Write> Writer for XmlWriter<W> {


### PR DESCRIPTION
This adds the `into_inner` method for `XmlWriter` which allows consumption of the plist writer and reclaiming the inner writer for future use.