### PR TITLE
binary plist writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.3.0"
 humantime = "1.1.1"
 line-wrap = "0.1.1"
 xml-rs = "0.8.0"
-serde = { version = "1.0.2", optional = true }
+serde = { version = "1.0.103", optional = true }
 
 [dev-dependencies]
-serde_derive = { version = "1.0.2" }
+serde_derive = { version = "1.0.103" }

--- a/src/date.rs
+++ b/src/date.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A UTC timestamp used for serialization to and from the plist date type.
-/// 
+///
 /// Note that while this type implements `Serialize` and `Deserialize` it will behave strangely if
 /// used with serializers from outside this crate.
-#[derive(Clone, Copy, Hash, PartialEq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Date {
     inner: SystemTime,
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -52,7 +52,7 @@ impl Date {
     pub(crate) fn to_seconds_since_plist_epoch(&self) -> f64 {
         // needed until #![feature(duration_float)] is stabilized
         fn as_secs_f64(d: Duration) -> f64 {
-            const NANOS_PER_SEC:f64 = 1_000_000_000.00;
+            const NANOS_PER_SEC: f64 = 1_000_000_000.00;
             (d.as_secs() as f64) + ((d.subsec_nanos() as f64) / NANOS_PER_SEC)
         }
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,6 +1,6 @@
 use humantime;
 use std::fmt;
-use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A UTC timestamp used for serialization to and from the plist date type.
 ///
@@ -26,7 +26,6 @@ impl Date {
     pub(crate) fn from_seconds_since_plist_epoch(timestamp: f64) -> Result<Date, ()> {
         // `timestamp` is the number of seconds since the plist epoch of 1/1/2001 00:00:00.
         // `PLIST_EPOCH_UNIX_TIMESTAMP` is the unix timestamp of the plist epoch.
-        const PLIST_EPOCH_UNIX_TIMESTAMP: u64 = 978_307_200;
         let plist_epoch = UNIX_EPOCH + Duration::from_secs(Date::PLIST_EPOCH_UNIX_TIMESTAMP);
 
         if !timestamp.is_finite() {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -15,6 +15,7 @@ use std::ops;
 use Value;
 
 /// Represents a plist dictionary type.
+#[derive(Eq, Hash)]
 pub struct Dictionary {
     map: BTreeMap<String, Value>,
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -50,7 +50,7 @@ impl FromStr for Integer {
             // NetBSD dialect adds the `0x` numeric objects,
             // which are always unsigned.
             // See the `PROP_NUMBER(3)` man page
-            let s = s.trim_left_matches("0x");
+            let s = s.trim_start_matches("0x");
 
             u64::from_str_radix(s, 16).map(Into::into)
         } else {

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -57,7 +57,6 @@ impl FromStr for Integer {
                 Err(_) => s.parse::<u64>()?.into(),
             })
         }
-
     }
 }
 

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -9,6 +9,10 @@ pub struct Integer {
 }
 
 impl Integer {
+    pub fn into_inner(self) -> i128 {
+        self.value
+    }
+
     pub fn as_signed(self) -> Option<i64> {
         if self.value >= i64::min_value().into() && self.value <= i64::max_value().into() {
             Some(self.value as i64)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@
 //! ```
 //!
 //!
-#![feature(duration_float)]
 
 extern crate base64;
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@
 //! # #[cfg(not(feature = "serde"))]
 //! # fn main() {}
 //! ```
+//!
+//!
+#![feature(duration_float)]
 
 extern crate base64;
 extern crate byteorder;
@@ -92,6 +95,7 @@ pub enum Error {
     UnexpectedEof,
     Io(io::Error),
     Serde(String),
+    InvalidDate(std::time::SystemTimeError),
 }
 
 impl ::std::error::Error for Error {
@@ -101,12 +105,14 @@ impl ::std::error::Error for Error {
             Error::UnexpectedEof => "unexpected eof",
             Error::Io(ref err) => err.description(),
             Error::Serde(ref err) => &err,
+            Error::InvalidDate(ref err) => "date is neither before nor after plist epoch?",
         }
     }
 
     fn cause(&self) -> Option<&::std::error::Error> {
         match *self {
             Error::Io(ref err) => Some(err),
+            Error::InvalidDate(ref err) => Some(err),
             _ => None,
         }
     }
@@ -124,6 +130,12 @@ impl fmt::Display for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::Io(err)
+    }
+}
+
+impl From<std::time::SystemTimeError> for Error {
+    fn from(err: std::time::SystemTimeError) -> Error {
+        Error::InvalidDate(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,11 +104,11 @@ impl ::std::error::Error for Error {
             Error::UnexpectedEof => "unexpected eof",
             Error::Io(ref err) => err.description(),
             Error::Serde(ref err) => &err,
-            Error::InvalidDate(ref err) => "date is neither before nor after plist epoch?",
+            Error::InvalidDate(ref _err) => "date is neither before nor after plist epoch?",
         }
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Io(ref err) => Some(err),
             Error::InvalidDate(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod ser;
 #[cfg(feature = "serde")]
 pub use self::de::{from_file, from_reader, from_reader_xml, Deserializer};
 #[cfg(feature = "serde")]
-pub use self::ser::{to_writer_xml, Serializer};
+pub use self::ser::{to_writer, to_writer_xml, Serializer};
 
 use std::fmt;
 use std::io;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -610,8 +610,9 @@ pub fn to_writer<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Result<()
     }
     let value = ::Value::from_events(events_oked)?;
 
-    let bin_writer = BinaryWriter::new(writer, value)?;
-    bin_writer.write()
+    let mut bin_writer = BinaryWriter::new(writer, value)?;
+    bin_writer.write()?;
+    Ok(())
 }
 
 /// Serializes the given data structure as an XML encoded plist file.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -598,7 +598,6 @@ impl<'a, W: Writer> ser::SerializeStructVariant for Compound<'a, W> {
 
 /// Serializes the given data structure as a binary encoded plist file.
 pub fn to_writer<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Result<(), Error> {
-    use std::ops::Drop;
     let mut ser = Serializer::new(VecWriter::new());
     value.serialize(&mut ser)?;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -596,6 +596,13 @@ impl<'a, W: Writer> ser::SerializeStructVariant for Compound<'a, W> {
     }
 }
 
+/// Serializes the given data structure as a binary encoded plist file.
+pub fn to_writer<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Result<(), Error> {
+    let writer = stream::XmlWriter::new(writer);
+    let mut ser = Serializer::new(writer);
+    value.serialize(&mut ser)
+}
+
 /// Serializes the given data structure as an XML encoded plist file.
 pub fn to_writer_xml<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Result<(), Error> {
     let writer = stream::XmlWriter::new(writer);

--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -91,7 +91,6 @@ impl<R: Read + Seek> BinaryReader<R> {
         self.reader.seek(SeekFrom::Start(offset_table_offset))?;
         self.object_offsets = self.read_ints(num_objects, offset_size)?;
         self.object_on_stack = vec![false; self.object_offsets.len()];
-
         Ok(())
     }
 

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -5,37 +5,342 @@ use stream::{Event, Writer};
 use {Date, Error, Integer};
 use {Serializer, Value};
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum RefSize {
+    U8,
+    U16,
+    U32,
+    U64,
+}
+
+impl RefSize {
+    fn into_offset_size(self) -> u8 {
+        match self {
+            RefSize::U8 => 1,
+            RefSize::U16 => 2,
+            RefSize::U32 => 4,
+            RefSize::U64 => 8,
+        }
+    }
+}
+
 /// Adapted from https://hg.python.org/cpython/file/3.4/Lib/plistlib.py
 pub struct BinaryWriter<W: Write> {
     writer: W,
     value: Value,
     object_list: Vec<Value>,
-    object_ref_table: HashMap<Value, u64>,
-    last_ref_num: u64,
+    object_ref_table: HashMap<Value, usize>,
+    object_offsets: Vec<usize>,
+    flattened: bool,
+    written: usize,
+    ref_size: RefSize,
 }
 
 impl<W: Write> BinaryWriter<W> {
     pub fn new(writer: W, value: Value) -> Result<BinaryWriter<W>, Error> {
         match value {
-            Value::Array(_) | Value::Dictionary(_) => {
-                let object_list = Vec::new();
-                let object_ref_table = HashMap::new();
-                let last_ref_num = 0u64;
-                Ok(BinaryWriter {
-                    writer,
-                    value,
-                    object_list,
-                    object_ref_table,
-                    last_ref_num,
-                })
-            }
+            Value::Array(_) | Value::Dictionary(_) => Ok(BinaryWriter {
+                writer,
+                value,
+                object_list: Vec::new(),
+                object_ref_table: HashMap::new(),
+                object_offsets: Vec::new(),
+                flattened: false,
+                written: 0,
+                ref_size: RefSize::U8,
+            }),
             _ => Err(Error::Serde(
                 "root object needs to be an Array or Dictionary".into(),
             )),
         }
     }
 
-    pub fn write(&self) -> Result<(), Error> {
-        Err(Error::Serde("BinaryWriter unimplemented".into()))
+    pub fn write(&mut self) -> Result<usize, Error> {
+        self.flatten();
+        let num_objects = self.object_list.len();
+        for _ in 0..num_objects {
+            self.object_offsets.push(0);
+        }
+        self.ref_size = BinaryWriter::<W>::size_of_count(&num_objects);
+
+        // write bplist header
+        self.written += self.write_header()?;
+
+        // write object list
+        // TODO: get rid of this clone
+        for o in self.object_list.clone() {
+            self.written += self.write_object(&o)?;
+        }
+
+        // write offset table
+        let top_object_ref_num = self.expect_ref_num(&self.value)?;
+        let offset_table_offset = self.written;
+        let offset_table_offset_size = BinaryWriter::<W>::size_of_count(&offset_table_offset);
+        // TODO: get rid of this clone
+        for offset in self.object_offsets.clone() {
+            self.written += self.write_int_sized(offset_table_offset_size, offset)?;
+        }
+
+        // write trailer
+        let sort_version = 0;
+
+        self.written += self.writer.write(&[
+            0, // first 4 bytes are unused
+            0,
+            0,
+            0,
+            sort_version, // then sort_version, whatever that is, which is apparently 0
+            offset_table_offset_size.into_offset_size(), // followed by size of an offset table entry
+            self.ref_size.clone().into_offset_size(),    // followed size of a reference entry
+        ])?;
+        // number of objects in object list, as u64be
+        self.written += self.writer.write(&(num_objects as u64).to_be_bytes())?;
+        // reference number of root object, as u64be
+        self.written += self
+            .writer
+            .write(&(top_object_ref_num as u64).to_be_bytes())?;
+        // start of offset table, relative to file.
+        self.written += self
+            .writer
+            .write(&(offset_table_offset as u64).to_be_bytes())?;
+        Ok(self.written)
+    }
+
+    fn write_header(&mut self) -> Result<usize, Error> {
+        let count = self.writer.write(b"bplist00")?;
+        Ok(count)
+    }
+
+    fn write_size(&mut self, token: u8, size: usize) -> Result<usize, Error> {
+        let mut count = 0usize;
+        if size < 15 {
+            count += self.writer.write(&[token | (size as u8 & 0xF)])?;
+        } else if size < (1 << 8) {
+            count += self.writer.write(&[token | 0xF, 0x10, size as u8])?;
+        } else if size < (1 << 16) {
+            count += self.writer.write(&[token | 0xF, 0x11])?;
+            count += self.writer.write(&(size as u16).to_be_bytes())?;
+        } else if size < (1 << 32) {
+            count += self.writer.write(&[token | 0xF, 0x12])?;
+            count += self.writer.write(&(size as u32).to_be_bytes())?;
+        } else {
+            count += self.writer.write(&[token | 0xF, 0x13])?;
+            count += self.writer.write(&(size as u64).to_be_bytes())?;
+        }
+        Ok(count)
+    }
+
+    fn write_int_sized(&mut self, ref_size: RefSize, ref_num: usize) -> Result<usize, Error> {
+        let bytes = match ref_size {
+            RefSize::U8 => [ref_num as u8].to_vec(),
+            RefSize::U16 => (ref_num as u16).to_be_bytes().to_vec(),
+            RefSize::U32 => (ref_num as u16).to_be_bytes().to_vec(),
+            RefSize::U64 => (ref_num as u64).to_be_bytes().to_vec(),
+        };
+        self.writer.write(bytes.as_slice()).map_err(Into::into)
+    }
+
+    fn write_ref_num(&mut self, ref_num: usize) -> Result<usize, Error> {
+        self.write_int_sized(self.ref_size, ref_num)
+    }
+
+    fn write_object(&mut self, v: &Value) -> Result<usize, Error> {
+        let ref_num = self.expect_ref_num(v)?;
+        self.object_offsets[ref_num] = self.written;
+        let mut count = 0usize;
+        match v {
+            Value::Boolean(b) => {
+                if *b {
+                    count += self.writer.write(&[0x08])?;
+                } else {
+                    count += self.writer.write(&[0x09])?;
+                }
+            }
+            Value::Integer(int) => {
+                let i = int.clone().into_inner();
+                if i < 0i128 {
+                    count += self.writer.write(&[0x13])?;
+                    count += self.writer.write(&(i as i64).to_be_bytes())?;
+                } else if i < (1 << 8) {
+                    count += self.writer.write(&[0x10, i as u8])?;
+                } else if i < (1 << 16) {
+                    count += self.writer.write(&[0x11])?;
+                    count += self.writer.write(&(i as u16).to_be_bytes())?;
+                } else if i < (1 << 32) {
+                    count += self.writer.write(&[0x12])?;
+                    count += self.writer.write(&(i as u32).to_be_bytes())?;
+                } else if i < (1 << 63) {
+                    count += self.writer.write(&[0x13])?;
+                    count += self.writer.write(&(i as u64).to_be_bytes())?;
+                } else if i < (1 << 64) {
+                    count += self.writer.write(&[0x14])?;
+                    count += self.writer.write(&i.to_be_bytes())?;
+                } else {
+                    return Err(Error::Serde(format!(
+                        "integer {} overflows plist min/max",
+                        i
+                    )));
+                }
+            }
+            Value::Real(r) => {
+                count += self.writer.write(&[0x23])?;
+                count += self.writer.write(&r.to_bits().to_be_bytes())?;
+            }
+            Value::Date(d) => {
+                let secs = &d
+                    .to_seconds_since_plist_epoch()
+                    .map_err(|e| Error::Serde(e.to_string()))?;
+                count += self.writer.write(&[0x33])?;
+                count += self.writer.write(&secs.to_bits().to_be_bytes())?;
+            }
+            Value::Data(d) => {
+                count += self.write_size(0x40, d.len())?;
+                count += self.writer.write(d.as_slice())?;
+            }
+            Value::String(s) => {
+                if s.is_ascii() {
+                    let ascii = s.as_bytes();
+                    count += self.write_size(0x50, ascii.len())?;
+                    count += self.writer.write(ascii)?;
+                } else {
+                    let utf16: Vec<u16> = s.encode_utf16().collect();
+                    count += self.write_size(0x60, utf16.len() * 2)?;
+                    for c in utf16 {
+                        count += self.writer.write(&c.to_be_bytes())?;
+                    }
+                }
+            }
+            Value::Array(a) => {
+                count += self.write_size(0xA0, a.len())?;
+                for elem in a {
+                    let ref_num = self.expect_ref_num(elem)?;
+                    count += self.write_ref_num(ref_num)?;
+                }
+            }
+            Value::Dictionary(d) => {
+                let (mut key_refs, mut val_refs) = (Vec::new(), Vec::new());
+                for (k, v) in d.iter() {
+                    key_refs.push(self.expect_ref_num(&Value::String(k.clone()))?);
+                    val_refs.push(self.expect_ref_num(v)?);
+                }
+                count += self.write_size(0xD0, key_refs.len())?;
+                for kr in key_refs {
+                    count += self.write_ref_num(kr)?;
+                }
+                for vr in val_refs {
+                    count += self.write_ref_num(vr)?;
+                }
+            }
+            Value::__Nonexhaustive => unreachable!(),
+        }
+
+        Ok(count)
+    }
+
+    fn flatten(&mut self) {
+        if !self.flattened {
+            self.flatten_inner(&self.value.clone());
+            self.flattened = true;
+        }
+    }
+
+    fn flatten_inner(&mut self, v: &Value) {
+        self.upsert_to_object_list(v);
+        match v {
+            Value::Dictionary(d) => {
+                let mut keys = Vec::new();
+                let mut values = Vec::new();
+                for (k, v) in d {
+                    keys.push(Value::String(k.clone()));
+                    values.push(v);
+                }
+
+                keys.iter().for_each(|k| self.flatten_inner(k));
+                values.iter().for_each(|v| self.flatten_inner(v));
+            }
+            Value::Array(a) => {
+                for v in a {
+                    self.flatten_inner(v)
+                }
+            }
+            _ => (),
+        }
+    }
+
+    fn get_ref_num(&self, v: &Value) -> Option<usize> {
+        return self.object_ref_table.get(v).map(Clone::clone);
+    }
+
+    fn expect_ref_num(&self, v: &Value) -> Result<usize, Error> {
+        match self.get_ref_num(v) {
+            Some(ref_num) => Ok(ref_num),
+            None => Err(Error::Serde(format!(
+                "expecting {:?} to already exist in ref table",
+                v
+            ))),
+        }
+    }
+
+    fn upsert_to_object_list(&mut self, v: &Value) -> usize {
+        match self.get_ref_num(v) {
+            Some(ref_num) => ref_num,
+            None => {
+                let ref_num = self.object_list.len();
+                self.object_list.push(v.clone());
+                self.object_ref_table.insert(v.clone(), ref_num);
+                ref_num
+            }
+        }
+    }
+
+    fn size_of_count(count: &usize) -> RefSize {
+        let ret = if count < &(1 << 8) {
+            RefSize::U8
+        } else if count < &(1 << 16) {
+            RefSize::U16
+        } else if count < &(1 << 32) {
+            RefSize::U32
+        } else {
+            RefSize::U64
+        };
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use humantime::parse_rfc3339_weak;
+    use std::fs::File;
+    use std::path::Path;
+
+    use super::*;
+    use std::io::Cursor;
+    use stream::BinaryReader;
+    use stream::Event;
+    use stream::Event::*;
+
+    fn test_roundtrip(path: &Path) {
+        let reader = File::open(path).unwrap();
+        let streaming_parser = BinaryReader::new(reader);
+        let value_to_encode = Value::from_events(streaming_parser).unwrap();
+
+        let mut buf = Cursor::new(Vec::new());
+        let value_encoded = value_to_encode.to_writer(&mut buf).unwrap();
+
+        let buf_inner = buf.into_inner();
+
+        let streaming_parser = BinaryReader::new(Cursor::new(buf_inner));
+        let value_decoded_from_encode = Value::from_events(streaming_parser).unwrap();
+
+        assert_eq!(value_to_encode, value_decoded_from_encode);
+    }
+
+    #[test]
+    fn bplist_roundtrip() {
+        test_roundtrip(&Path::new("./tests/data/binary.plist"))
+    }
+
+    fn utf16_roundtrip() {
+        test_roundtrip(&Path::new("./tests/data/utf16_bplist.plist"))
     }
 }

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -1,9 +1,6 @@
 use std::io::Write;
-
 use std::collections::HashMap;
-use stream::{Event, Writer};
-use {Date, Error, Integer};
-use {Serializer, Value};
+use super::{Date, Error, Integer, Value};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum RefSize {

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -1,0 +1,41 @@
+use std::io::Write;
+
+use std::collections::HashMap;
+use stream::{Event, Writer};
+use {Date, Error, Integer};
+use {Serializer, Value};
+
+/// Adapted from https://hg.python.org/cpython/file/3.4/Lib/plistlib.py
+pub struct BinaryWriter<W: Write> {
+    writer: W,
+    value: Value,
+    object_list: Vec<Value>,
+    object_ref_table: HashMap<Value, u64>,
+    last_ref_num: u64,
+}
+
+impl<W: Write> BinaryWriter<W> {
+    pub fn new(writer: W, value: Value) -> Result<BinaryWriter<W>, Error> {
+        match value {
+            Value::Array(_) | Value::Dictionary(_) => {
+                let object_list = Vec::new();
+                let object_ref_table = HashMap::new();
+                let last_ref_num = 0u64;
+                Ok(BinaryWriter {
+                    writer,
+                    value,
+                    object_list,
+                    object_ref_table,
+                    last_ref_num,
+                })
+            }
+            _ => Err(Error::Serde(
+                "root object needs to be an Array or Dictionary".into(),
+            )),
+        }
+    }
+
+    pub fn write(&self) -> Result<(), Error> {
+        Err(Error::Serde("BinaryWriter unimplemented".into()))
+    }
+}

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -184,9 +184,7 @@ impl<W: Write> BinaryWriter<W> {
                 count += self.writer.write(&r.to_bits().to_be_bytes())?;
             }
             Value::Date(d) => {
-                let secs = &d
-                    .to_seconds_since_plist_epoch()
-                    .map_err(|e| Error::Serde(e.to_string()))?;
+                let secs = &d.to_seconds_since_plist_epoch();
                 count += self.writer.write(&[0x33])?;
                 count += self.writer.write(&secs.to_bits().to_be_bytes())?;
             }

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -1,4 +1,4 @@
-use super::{Date, Error, Integer, Value};
+use super::{Error, Value};
 use std::collections::HashMap;
 use std::io::Write;
 

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -204,7 +204,7 @@ impl<W: Write> BinaryWriter<W> {
                     count += self.writer.write(ascii)?;
                 } else {
                     let utf16: Vec<u16> = s.encode_utf16().collect();
-                    count += self.write_size(0x60, utf16.len() * 2)?;
+                    count += self.write_size(0x60, utf16.len())?;
                     for c in utf16 {
                         count += self.writer.write(&c.to_be_bytes())?;
                     }
@@ -340,6 +340,7 @@ mod tests {
         test_roundtrip(&Path::new("./tests/data/binary.plist"))
     }
 
+    #[test]
     fn utf16_roundtrip() {
         test_roundtrip(&Path::new("./tests/data/utf16_bplist.plist"))
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3,6 +3,9 @@
 mod binary_reader;
 pub use self::binary_reader::BinaryReader;
 
+mod binary_writer;
+pub use self::binary_writer::BinaryWriter;
+
 mod xml_reader;
 pub use self::xml_reader::XmlReader;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -54,7 +54,7 @@ impl Value {
         self.to_writer_xml_inner(&mut writer)
     }
 
-    fn to_writer_xml_inner(&self, writer: &mut Writer) -> Result<(), Error> {
+    fn to_writer_xml_inner(&self, writer: &mut dyn Writer) -> Result<(), Error> {
         let events = self.clone().into_events();
         for event in events {
             writer.write(&event)?;

--- a/src/value.rs
+++ b/src/value.rs
@@ -43,8 +43,9 @@ impl Value {
 
     /// Serializes the given data structure as a binary plist file.
     pub fn to_writer<W: Write>(&self, writer: W) -> Result<(), Error> {
-        let binary_writer = BinaryWriter::new(writer, self.clone())?;
-        binary_writer.write()
+        let mut binary_writer = BinaryWriter::new(writer, self.clone())?;
+        binary_writer.write()?;
+        Ok(())
     }
 
     /// Serializes the given data structure as an XML encoded plist file.


### PR DESCRIPTION
Hey! 

I thought I'd take a stab at #28 as a means of getting more familiar with Rust (as well as because I need it for another project I'm working on). I opted to not make it a streaming writer like the XML writer is, as you need to know the length of any root object (i.e., array or dictionary) anyway and would end up re-creating much of the logic of `Value::from_events`. There are some inefficiencies that probably need resolving, and any feedback would be appreciated. Additionally, I think some of the writer mutation could be better encapsulated, but it's a start.

Included are two tests for roundtripping the binary plists in data/, and they seem to work fine.