### PR TITLE
Loosen dependency specifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ default = ["serde"]
 enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
-base64 = "0.10.1"
-humantime = "1.1.1"
-indexmap = "1.0.2"
-line-wrap = "0.1.1"
-xml_rs = { package = "xml-rs", version = "0.8.0" }
-serde = { version = "1.0.2", optional = true }
+base64 = "~0.10.1"
+humantime = "~1.1.1"
+indexmap = "~1.0.2"
+line-wrap = "~0.1.1"
+xml_rs = { package = "xml-rs", version = "~0.8.0" }
+serde = { version = "~1.0.2", optional = true }
 
 [dev-dependencies]
-serde_derive = { version = "1.0.2" }
+serde_derive = { version = "~1.0.2" }


### PR DESCRIPTION
This PR loosens the dependency specifiers for this libraries dependencies. Right now there is an exact lock on using Serde `1.0.2`, not `1.0.3` or the most recent release `1.0.102`.

As this is a library rather than a tool it should have looser dependency specifiers if possible, so it can be consumed by projects that may have a dependency on `serde>1.0.2` (due to bugfixes, other libraries etc).

I'm fairly certain things like `base64` could be bumped to `~0.11.0` as well, but that can be done another time perhaps.