### PR TITLE
Make sure offset_table_offset is written as 8 bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ rust:
   - beta
   - stable
   - 1.32.0
+matrix:
+  include:
+    - os: linux
+      rust: stable-i686-unknown-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
 script:
   - cargo check --no-default-features
   - cargo check --no-default-features --features enable_unstable_features_that_may_break_with_minor_version_bumps

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -335,7 +335,7 @@ impl<W: Write> BinaryWriter<W> {
         trailer[6] = offset_size;
         trailer[7] = ref_size;
         trailer[8..16].copy_from_slice(&(self.num_objects as u64).to_be_bytes());
-        trailer[24..32].copy_from_slice(&offset_table_offset.to_be_bytes());
+        trailer[24..32].copy_from_slice(&(offset_table_offset as u64).to_be_bytes());
         self.writer.write_exact(&trailer)?;
 
         self.writer


### PR DESCRIPTION
It's a `usize` value, but the output format expects 8 bytes. That's fine
on 64-bit targets, but 32-bit targets were failing tests:

    ---- stream::binary_writer::tests::bplist_roundtrip stdout ----
    thread 'stream::binary_writer::tests::bplist_roundtrip' panicked at 'assertion failed: `(left == right)`
      left: `8`,
     right: `4`: destination and source slices have different lengths', src/libcore/slice/mod.rs:2217:9
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
    ---- stream::binary_writer::tests::nskeyedarchiver_roundtrip stdout ----
    thread 'stream::binary_writer::tests::nskeyedarchiver_roundtrip' panicked at 'assertion failed: `(left == right)`
      left: `8`,
     right: `4`: destination and source slices have different lengths', src/libcore/slice/mod.rs:2217:9
    ---- stream::binary_writer::tests::utf16_roundtrip stdout ----
    thread 'stream::binary_writer::tests::utf16_roundtrip' panicked at 'assertion failed: `(left == right)`
      left: `8`,
     right: `4`: destination and source slices have different lengths', src/libcore/slice/mod.rs:2217:9

Casting to `u64` makes sure we have the correct size to write.