### PR TITLE
Replace `humantime` with `chrono` to support dates before 1970.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.10.1"
-humantime = "2.0.0"
 indexmap = "1.0.2"
+chrono = "0.4.10"
 line-wrap = "0.1.1"
 xml_rs = { package = "xml-rs", version = "0.8.0" }
 serde = { version = "1.0.2", optional = true }

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,4 +1,4 @@
-use humantime;
+use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use std::{
     fmt,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -20,13 +20,15 @@ impl Date {
     const PLIST_EPOCH_UNIX_TIMESTAMP: Duration = Duration::from_secs(978_307_200);
 
     pub(crate) fn from_rfc3339(date: &str) -> Result<Self, ()> {
+        let offset: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(date).map_err(|_| ())?;
         Ok(Date {
-            inner: humantime::parse_rfc3339(date).map_err(|_| ())?,
+            inner: offset.with_timezone(&Utc).into(),
         })
     }
 
     pub(crate) fn to_rfc3339(&self) -> String {
-        format!("{}", humantime::format_rfc3339(self.inner))
+        let datetime: DateTime<Utc> = self.inner.into();
+        datetime.to_rfc3339_opts(SecondsFormat::AutoSi, true)
     }
 
     pub(crate) fn from_seconds_since_plist_epoch(
@@ -72,8 +74,7 @@ impl Date {
 
 impl fmt::Debug for Date {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let rfc3339 = humantime::format_rfc3339(self.inner);
-        <humantime::Rfc3339Timestamp as fmt::Display>::fmt(&rfc3339, f)
+        write!(f, "{}", self.to_rfc3339())
     }
 }
 
@@ -153,4 +154,27 @@ pub mod serde_impls {
             deserializer.deserialize_newtype_struct(DATE_NEWTYPE_STRUCT_NAME, DateNewtypeVisitor)
         }
     }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    #[test]
+    fn date_roundtrip() {
+        let date_str = "1981-05-16T11:32:06Z";
+
+        let date = Date::from_rfc3339(date_str).expect("should parse");
+
+        let generated_str = date.to_rfc3339();
+
+        assert_eq!(date_str, generated_str);
+    }
+
+    #[test]
+    fn far_past_date() {
+        let date_str = "1920-01-01T00:00:00Z";
+        Date::from_rfc3339(date_str).expect("should parse");
+    }
+
 }

--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -409,7 +409,6 @@ impl<R: Read + Seek> Iterator for BinaryReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use humantime::parse_rfc3339_weak;
     use std::{fs::File, path::Path};
 
     use super::*;
@@ -432,7 +431,7 @@ mod tests {
             String("Data".into()),
             Data(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
             String("Birthdate".into()),
-            Date(parse_rfc3339_weak("1981-05-16 11:32:06").unwrap().into()),
+            Date(super::Date::from_rfc3339("1981-05-16T11:32:06Z").unwrap()),
             String("BiggestNumber".into()),
             Integer(18446744073709551615u64.into()),
             String("SmallestNumber".into()),

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -218,7 +218,6 @@ fn from_xml_error(err: XmlReaderError) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use humantime::parse_rfc3339_weak;
     use std::{fs::File, path::Path};
 
     use super::*;
@@ -246,7 +245,7 @@ mod tests {
             String("Data".to_owned()),
             Data(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
             String("Birthdate".to_owned()),
-            Date(parse_rfc3339_weak("1981-05-16 11:32:06").unwrap().into()),
+            Date(super::Date::from_rfc3339("1981-05-16T11:32:06Z").unwrap()),
             String("Blank".to_owned()),
             String("".to_owned()),
             String("BiggestNumber".to_owned()),

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -291,7 +291,6 @@ fn base64_encode_plist(data: &[u8], indent: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use humantime::parse_rfc3339_weak;
     use std::io::Cursor;
 
     use super::*;
@@ -316,7 +315,7 @@ mod tests {
             Event::String("Data".to_owned()),
             Event::Data(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0]),
             Event::String("Birthdate".to_owned()),
-            Event::Date(parse_rfc3339_weak("1981-05-16 11:32:06").unwrap().into()),
+            Event::Date(super::Date::from_rfc3339("1981-05-16T11:32:06Z").unwrap()),
             Event::String("Comment".to_owned()),
             Event::String("2 < 3".to_owned()), // make sure characters are escaped
             Event::String("BiggestNumber".to_owned()),


### PR DESCRIPTION
When using `rust-plist` to parse an iTunes library file, I ran into parsing errors with particularly old `<date>` values. As it turns out, the `humantime` crate returns an `OutOfRange` error while parsing any date before 1970. This behavior is technically out of spec, as [RFC3339 is defined for all years "somewhere between 0000AD and 9999AD"](https://tools.ietf.org/html/rfc3339)

This patch entirely replaces the `humantime` crate with `chrono`, and adds a test case with a date before 1970 to prevent regressions.