### PR TITLE
Bump versions and make default option mode to Root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ default = ["serde"]
 enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
-base64 = "0.12.0"
-chrono = { version = "0.4.11", default-features = false, features = ["std"] }
-indexmap = "1.0.2"
+base64 = "0.13"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
+indexmap = "1.6"
 line-wrap = "0.1.1"
-xml_rs = { package = "xml-rs", version = "0.8.0" }
-serde = { version = "1.0.2", optional = true }
+xml-rs = "0.8"
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-serde_derive = { version = "1.0.2" }
+serde_derive = { version = "1.0" }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -22,11 +22,18 @@ impl ser::Error for Error {
     }
 }
 
+#[allow(dead_code)]
 enum OptionMode {
     Root,
     StructField(&'static str),
     StructFieldNameWritten,
     Explicit,
+}
+
+impl Default for OptionMode {
+    fn default() -> Self {
+        Self::Root
+    }
 }
 
 /// A structure that serializes Rust values plist event streams.
@@ -203,11 +210,11 @@ impl<'a, W: Writer> ser::Serializer for &'a mut Serializer<W> {
 
     fn serialize_some<T: ?Sized + ser::Serialize>(self, value: &T) -> Result<(), Error> {
         match self.option_mode {
-            OptionMode::Root => self.serialize_with_option_mode(OptionMode::Explicit, value)?,
+            OptionMode::Root => self.serialize_with_option_mode(OptionMode::default(), value)?,
             OptionMode::StructField(field_name) => {
                 self.option_mode = OptionMode::StructFieldNameWritten;
                 self.write_string(field_name)?;
-                self.serialize_with_option_mode(OptionMode::Explicit, value)?;
+                self.serialize_with_option_mode(OptionMode::default(), value)?;
             }
             OptionMode::StructFieldNameWritten => unreachable!(),
             OptionMode::Explicit => {
@@ -656,8 +663,7 @@ impl<'a, W: Writer> ser::SerializeSeq for Compound<'a, W> {
     type Error = Error;
 
     fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, value)
+        self.ser.serialize_with_option_mode(OptionMode::default(), value)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
@@ -670,8 +676,7 @@ impl<'a, W: Writer> ser::SerializeTuple for Compound<'a, W> {
     type Error = Error;
 
     fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, value)
+        self.ser.serialize_with_option_mode(OptionMode::default(), value)
     }
 
     fn end(self) -> Result<(), Error> {
@@ -684,8 +689,7 @@ impl<'a, W: Writer> ser::SerializeTupleStruct for Compound<'a, W> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, value)
+        self.ser.serialize_with_option_mode(OptionMode::default(), value)
     }
 
     fn end(self) -> Result<(), Error> {
@@ -698,8 +702,7 @@ impl<'a, W: Writer> ser::SerializeTupleVariant for Compound<'a, W> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, value)
+        self.ser.serialize_with_option_mode(OptionMode::default(), value)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
@@ -713,13 +716,11 @@ impl<'a, W: Writer> ser::SerializeMap for Compound<'a, W> {
     type Error = Error;
 
     fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, key: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, key)
+        self.ser.serialize_with_option_mode(OptionMode::default(), key)
     }
 
     fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<(), Error> {
-        self.ser
-            .serialize_with_option_mode(OptionMode::Explicit, value)
+        self.ser.serialize_with_option_mode(OptionMode::default(), value)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -175,12 +175,12 @@ impl<R: Read + Seek> Iterator for Reader<R> {
             Ok(true) => ReaderInner::Binary(BinaryReader::new(reader)),
             Ok(false) => ReaderInner::Xml(XmlReader::new(reader)),
             Err(err) => {
-                ::std::mem::replace(&mut self.0, ReaderInner::Uninitialized(Some(reader)));
+                let _ = std::mem::replace(&mut self.0, ReaderInner::Uninitialized(Some(reader)));
                 return Some(Err(err));
             }
         };
 
-        ::std::mem::replace(&mut self.0, event_reader);
+        let _ = std::mem::replace(&mut self.0, event_reader);
 
         self.next()
     }

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, Read},
     str::FromStr,
 };
-use xml_rs::{
+use xml::{
     common::{is_whitespace_str, Position},
     reader::{
         Error as XmlReaderError, ErrorKind as XmlReaderErrorKind, EventReader, ParserConfig,
@@ -190,7 +190,7 @@ impl<R: Read> Iterator for XmlReader<R> {
     }
 }
 
-fn convert_xml_pos(pos: xml_rs::common::TextPosition) -> FilePosition {
+fn convert_xml_pos(pos: xml::common::TextPosition) -> FilePosition {
     // TODO: pos.row and pos.column counts from 0. what do we want to do?
     FilePosition::LineColumn(pos.row, pos.column)
 }

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -1,7 +1,7 @@
 use base64;
 use line_wrap;
 use std::{borrow::Cow, io::Write};
-use xml_rs::{
+use xml::{
     name::Name,
     namespace::Namespace,
     writer::{EmitterConfig, Error as XmlWriterError, EventWriter, XmlEvent},
@@ -88,6 +88,7 @@ impl<W: Write> XmlWriter<W> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn into_inner(self) -> W {
         self.xml_writer.into_inner()
     }


### PR DESCRIPTION
First, it bumps Cargo versions. Second, it makes OptionMode default to Root to fix this kind of stuff:
```rs
#[serde(
    rename = "UIRequiresFullScreen",
    skip_serializing_if = "Option::is_none"
)]
requires_full_screen: Option<bool>
```
Results in:
```xml
<key>UIRequiresFullScreen</key>
<dict>
    <key>Some</key>
    <false />
</dict>
```

I haven't found how to work-around it and made changes to rust-plist. Also, I used rust-plist for our `Info.plist` [implementation](https://github.com/creator-rs/creator/tree/master/crates/creator-build/src/types/info_plist).