### PR TITLE
Proposal: customizing XML serialization behaviour

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -80,6 +80,17 @@ impl Dictionary {
         self.map.retain(keep)
     }
 
+    /// Sort the dictionary keys.
+    ///
+    /// This uses the default ordering defined on [`str`].
+    ///
+    /// This function is useful if you are serializing to XML, and wish to
+    /// ensure a consistent key order.
+    #[inline]
+    pub fn sort_keys(&mut self) {
+        self.map.sort_keys()
+    }
+
     /// Gets the given key's corresponding entry in the dictionary for in-place manipulation.
     // Entry functionality is unstable until I can figure out how to use either Cow<str> or
     // T: AsRef<str> + Into<String>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub use date::Date;
 pub use dictionary::Dictionary;
 pub use error::Error;
 pub use integer::Integer;
+pub use stream::XmlWriteOptions;
 pub use uid::Uid;
 pub use value::Value;
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -87,24 +87,27 @@ enum StackItem<'a> {
 
 /// Options for customizing serialization of XML plists.
 #[derive(Clone, Debug)]
-pub struct WriteOptions {
-    indent_str: &'static str,
+pub struct XmlWriteOptions {
+    indent_str: Cow<'static, str>,
 }
 
-impl WriteOptions {
+impl XmlWriteOptions {
     /// Specify the sequence of characters used for indentation.
     ///
+    /// This may be either an `&'static str` or an owned `String`.
+    ///
     /// The default is `\t`.
-    #[cfg(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
-    pub fn indent_string(mut self, indent_str: &'static str) -> Self {
-        self.indent_str = indent_str;
+    pub fn indent_string(mut self, indent_str: impl Into<Cow<'static, str>>) -> Self {
+        self.indent_str = indent_str.into();
         self
     }
 }
 
-impl Default for WriteOptions {
+impl Default for XmlWriteOptions {
     fn default() -> Self {
-        WriteOptions { indent_str: "\t" }
+        XmlWriteOptions {
+            indent_str: Cow::Borrowed("\t"),
+        }
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -85,6 +85,29 @@ enum StackItem<'a> {
     DictValue(&'a Value),
 }
 
+/// Options for customizing serialization of XML plists.
+#[derive(Clone, Debug)]
+pub struct WriteOptions {
+    indent_str: &'static str,
+}
+
+impl WriteOptions {
+    /// Specify the sequence of characters used for indentation.
+    ///
+    /// The default is `\t`.
+    #[cfg(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
+    pub fn indent_string(mut self, indent_str: &'static str) -> Self {
+        self.indent_str = indent_str;
+        self
+    }
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        WriteOptions { indent_str: "\t" }
+    }
+}
+
 impl<'a> Events<'a> {
     pub(crate) fn new(value: &'a Value) -> Events<'a> {
         Events {

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -9,7 +9,7 @@ use xml_rs::{
 
 use crate::{
     error::{self, Error, ErrorKind, EventKind},
-    stream::{WriteOptions, Writer},
+    stream::{Writer, XmlWriteOptions},
     Date, Integer, Uid,
 };
 
@@ -35,14 +35,14 @@ pub struct XmlWriter<W: Write> {
 
 impl<W: Write> XmlWriter<W> {
     pub fn new(writer: W) -> XmlWriter<W> {
-        let opts = WriteOptions::default();
+        let opts = XmlWriteOptions::default();
         XmlWriter::new_with_options(writer, &opts)
     }
 
-    pub fn new_with_options(writer: W, opts: &WriteOptions) -> XmlWriter<W> {
+    pub fn new_with_options(writer: W, opts: &XmlWriteOptions) -> XmlWriter<W> {
         let config = EmitterConfig::new()
             .line_separator("\n")
-            .indent_string(opts.indent_str)
+            .indent_string(opts.indent_str.clone())
             .perform_indent(true)
             .write_document_declaration(false)
             .normalize_empty_elements(true)

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -9,7 +9,7 @@ use xml_rs::{
 
 use crate::{
     error::{self, Error, ErrorKind, EventKind},
-    stream::Writer,
+    stream::{WriteOptions, Writer},
     Date, Integer, Uid,
 };
 
@@ -35,9 +35,14 @@ pub struct XmlWriter<W: Write> {
 
 impl<W: Write> XmlWriter<W> {
     pub fn new(writer: W) -> XmlWriter<W> {
+        let opts = WriteOptions::default();
+        XmlWriter::new_with_options(writer, &opts)
+    }
+
+    pub fn new_with_options(writer: W, opts: &WriteOptions) -> XmlWriter<W> {
         let config = EmitterConfig::new()
             .line_separator("\n")
-            .indent_string("\t")
+            .indent_string(opts.indent_str)
             .perform_indent(true)
             .write_document_declaration(false)
             .normalize_empty_elements(true)

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,7 +7,8 @@ use std::{
 use crate::{
     error::{self, Error, ErrorKind, EventKind},
     stream::{
-        BinaryWriter, Event, Events, OwnedEvent, Reader, WriteOptions, Writer, XmlReader, XmlWriter,
+        BinaryWriter, Event, Events, OwnedEvent, Reader, Writer, XmlReader, XmlWriteOptions,
+        XmlWriter,
     },
     u64_to_usize, Date, Dictionary, Integer, Uid,
 };
@@ -71,10 +72,10 @@ impl Value {
 
     /// Serializes a `Value` to a byte stream as an XML encoded plist.
     pub fn to_writer_xml<W: Write>(&self, writer: W) -> Result<(), Error> {
-        self.to_writer_xml_with_options(writer, WriteOptions::default())
+        self.to_writer_xml_with_options(writer, &XmlWriteOptions::default())
     }
 
-    /// Serializes a `Value` to a stream, using custom [`WriteOptions`].
+    /// Serializes a `Value` to a stream, using custom [`XmlWriteOptions`].
     ///
     /// If you need to serialize to a file, you must acquire an appropriate
     /// `Write` handle yourself.
@@ -84,33 +85,21 @@ impl Value {
     /// ```no_run
     /// use std::io::{BufWriter, Write};
     /// use std::fs::File;
-    /// use plist::{Dictionary, Value};
-    /// use plist::stream::{WriteOptions, XmlWriter};
+    /// use plist::{Dictionary, Value, XmlWriteOptions};
     ///
     /// let value: Value = Dictionary::new().into();
     /// // .. add some keys & values
     /// let mut file = File::create("com.example.myPlist.plist").unwrap();
-    /// let options = WriteOptions::default().indent_string("  ");
-    /// value.to_writer_xml_with_options(BufWriter::new(&mut file), options).unwrap();
+    /// let options = XmlWriteOptions::default().indent_string("  ");
+    /// value.to_writer_xml_with_options(BufWriter::new(&mut file), &options).unwrap();
     /// file.sync_all().unwrap();
     /// ```
-    #[cfg(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
     pub fn to_writer_xml_with_options<W: Write>(
         &self,
         writer: W,
-        options: WriteOptions,
+        options: &XmlWriteOptions,
     ) -> Result<(), Error> {
-        let mut writer = XmlWriter::new_with_options(writer, &options);
-        self.to_writer_inner(&mut writer)
-    }
-
-    #[cfg(not(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps"))]
-    pub(crate) fn to_writer_xml_with_options<W: Write>(
-        &self,
-        writer: W,
-        options: WriteOptions,
-    ) -> Result<(), Error> {
-        let mut writer = XmlWriter::new_with_options(writer, &options);
+        let mut writer = XmlWriter::new_with_options(writer, options);
         self.to_writer_inner(&mut writer)
     }
 


### PR DESCRIPTION
So I started out trying to write up a proposal for this as an issue, but then I realized I didn't know how feasible the implementation would be, so I did the impl first, which I present here for discussion.

This implements two bits of related behaviour that are important for my (admittedly obscure) use case.

- this allows passing a custom string to be used as the whitespace marker for indentation
- this allows setting a flag that causes us to sort dictionary keys during serialization

The second item is definitely the weirdest; currently it relies on the fact that we're using `IndexMap`, although we could implement it for other maps in less efficient ways.

This patch does not (to the best of my knowledge) break the existing API. It adds a new method, `Value::to_writer_xml_with_options`, that accepts a new `WriteOptions` struct. This new API is hidden behind the `enable_unstable_features_that_may_break_with_minor_version_bumps` feature.

I have not added too many options; adding more should be easy.

I appreciate that this is... a little weird, but I've run into a few places where I've needed to do this sort of customization, mostly in situations where I am matching the output of existing tooling, and want to minimize the size of diffs.


Let me know if you have any questions!