### PR TITLE
Add .pad_self_closing(false) to improve compatibility with Apple's XML parser

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.36.0
+            channel: 1.38.0
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             channel: stable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.38.0
+            channel: 1.40.0
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             channel: stable

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -48,7 +48,8 @@ impl<W: Write> XmlWriter<W> {
             .normalize_empty_elements(true)
             .cdata_to_characters(true)
             .keep_element_names_stack(false)
-            .autopad_comments(true);
+            .autopad_comments(true)
+            .pad_self_closing(false);
 
         XmlWriter {
             xml_writer: EventWriter::new_with_config(writer, config),
@@ -377,9 +378,9 @@ mod tests {
 \t<key>SmallestNumber</key>
 \t<integer>-9223372036854775808</integer>
 \t<key>IsTrue</key>
-\t<true />
+\t<true/>
 \t<key>IsNotFalse</key>
-\t<false />
+\t<false/>
 </dict>
 </plist>";
 


### PR DESCRIPTION
Adds `.pad_self_closing(false)` to the initialization of the `EmitterConfig` used by `stream::XmlWriter`.

This change causes self-closing tags to be generated as, for example, `<true/>` rather than `<true />`. Apple XML parser used by the `codesign` utility does not accept the later as valid.

See #65 for discussion.