### PR TITLE
Bump minimum supported Rust version.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.36.0
+            channel: 1.38.0
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             channel: stable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.38.0
+            channel: 1.40.0
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             channel: stable


### PR DESCRIPTION
We now depend on a newer version of `hashbrown` which depends on the `ptr_cast` feature which was stabilised in Rust 1.38.