### PR TITLE
Add ser::to_writer_xml_with_options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,9 @@ pub use self::{de::Deserializer, ser::Serializer};
 #[cfg(feature = "serde")]
 pub use self::{
     de::{from_bytes, from_file, from_reader, from_reader_xml},
-    ser::{to_file_binary, to_file_xml, to_writer_binary, to_writer_xml},
+    ser::{
+        to_file_binary, to_file_xml, to_writer_binary, to_writer_xml, to_writer_xml_with_options,
+    },
 };
 
 #[cfg(all(test, feature = "serde"))]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -12,7 +12,7 @@ use crate::{
     error::{self, Error, ErrorKind},
     stream::{self, Writer},
     uid::serde_impls::UID_NEWTYPE_STRUCT_NAME,
-    Date, Integer, Uid,
+    Date, Integer, Uid, XmlWriteOptions,
 };
 
 #[doc(hidden)]
@@ -789,7 +789,16 @@ pub fn to_writer_binary<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Re
 
 /// Serializes the given data structure to a byte stream as an XML encoded plist.
 pub fn to_writer_xml<W: Write, T: ser::Serialize>(writer: W, value: &T) -> Result<(), Error> {
-    let writer = stream::XmlWriter::new(writer);
+    to_writer_xml_with_options(writer, value, &XmlWriteOptions::default())
+}
+
+/// Serializes to a byte stream as an XML encoded plist, using custom [`XmlWriteOptions`].
+pub fn to_writer_xml_with_options<W: Write, T: ser::Serialize>(
+    writer: W,
+    value: &T,
+    options: &XmlWriteOptions,
+) -> Result<(), Error> {
+    let writer = stream::XmlWriter::new_with_options(writer, options);
     let mut ser = Serializer::new(writer);
     value.serialize(&mut ser)
 }


### PR DESCRIPTION
This was an oversight, and should've been added along with the equivalent
method on Value.

No rush with this; I can get along fine using the `big_long_unstable_feature` to create an `XmlWriter` myself.

I'm starting to integrate the new changes into my project, so I may run into a few other things in the process.