### PR TITLE
fix: Switch to using time-rs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.40.0
+            channel: 1.51.0
           - os: ubuntu-18.04
             target: x86_64-unknown-linux-gnu
             channel: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.13.0"
-chrono = { version = "0.4.11", default-features = false, features = ["std"] }
+time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"
 xml_rs = { package = "xml-rs", version = "0.8.0" }

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,8 +1,8 @@
-use chrono::{DateTime, FixedOffset, SecondsFormat, Utc};
 use std::{
     fmt,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use time::{format_description::well_known::Rfc3339, OffsetDateTime, UtcOffset};
 
 /// A UTC timestamp used for serialization to and from the plist date type.
 ///
@@ -20,15 +20,17 @@ impl Date {
     const PLIST_EPOCH_UNIX_TIMESTAMP: Duration = Duration::from_secs(978_307_200);
 
     pub(crate) fn from_rfc3339(date: &str) -> Result<Self, ()> {
-        let offset: DateTime<FixedOffset> = DateTime::parse_from_rfc3339(date).map_err(|_| ())?;
+        let offset: OffsetDateTime = OffsetDateTime::parse(date, &Rfc3339)
+            .map_err(|_| ())?
+            .to_offset(UtcOffset::UTC);
         Ok(Date {
-            inner: offset.with_timezone(&Utc).into(),
+            inner: offset.into(),
         })
     }
 
     pub(crate) fn to_rfc3339(&self) -> String {
-        let datetime: DateTime<Utc> = self.inner.into();
-        datetime.to_rfc3339_opts(SecondsFormat::Secs, true)
+        let datetime: OffsetDateTime = self.inner.into();
+        datetime.format(&Rfc3339).unwrap()
     }
 
     pub(crate) fn from_seconds_since_plist_epoch(


### PR DESCRIPTION
Currently chrono has a vulnerability in it. This switches to the
underlying time-rs library that chrono uses.

https://rustsec.org/advisories/RUSTSEC-2020-0159
