### PR TITLE
Implements HashMap to Dictionary.

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -726,17 +726,17 @@ pub mod serde_impls {
 #[cfg(test)]
 mod tests {
     use super::Dictionary;
-    use std::collections::HashMap;
+    use std::array::IntoIter;
 
     #[test]
     fn from_hash_map_to_dict() {
-        let dogs = HashMap::from([
+        let dict: Dictionary = IntoIter::new([
             ("Doge", "Shiba Inu"),
             ("Cheems", "Shiba Inu"),
             ("Walter", "Bull Terrier"),
             ("Perro", "Golden Retriever"),
-        ]);
-        let dict: Dictionary = dogs.into_iter().collect();
+        ])
+        .collect();
         assert_eq!(
             dict.get("Doge").and_then(|v| v.as_string()),
             Some("Shiba Inu")

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -728,10 +728,8 @@ mod tests {
     use super::Dictionary;
     use std::collections::HashMap;
 
-
     #[test]
     fn from_hash_map_to_dict() {
-        
         let dogs = HashMap::from([
             ("Doge", "Shiba Inu"),
             ("Cheems", "Shiba Inu"),
@@ -739,10 +737,21 @@ mod tests {
             ("Perro", "Golden Retriever"),
         ]);
         let dict: Dictionary = dogs.into_iter().collect();
-        assert_eq!(dict.get("Doge").and_then(|v| v.as_string()), Some("Shiba Inu"));
-        assert_eq!(dict.get("Cheems").and_then(|v| v.as_string()), Some("Shiba Inu"));
-        assert_eq!(dict.get("Walter").and_then(|v| v.as_string()), Some("Bull Terrier"));
-        assert_eq!(dict.get("Perro").and_then(|v| v.as_string()), Some("Golden Retriever"));
+        assert_eq!(
+            dict.get("Doge").and_then(|v| v.as_string()),
+            Some("Shiba Inu")
+        );
+        assert_eq!(
+            dict.get("Cheems").and_then(|v| v.as_string()),
+            Some("Shiba Inu")
+        );
+        assert_eq!(
+            dict.get("Walter").and_then(|v| v.as_string()),
+            Some("Bull Terrier")
+        );
+        assert_eq!(
+            dict.get("Perro").and_then(|v| v.as_string()),
+            Some("Golden Retriever")
+        );
     }
-
 }

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -230,13 +230,13 @@ impl Debug for Dictionary {
     }
 }
 
-impl FromIterator<(String, Value)> for Dictionary {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = (String, Value)>,
-    {
+impl<K: Into<String>, V: Into<Value>> FromIterator<(K, V)> for Dictionary {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         Dictionary {
-            map: FromIterator::from_iter(iter),
+            map: iter
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         }
     }
 }
@@ -721,4 +721,28 @@ pub mod serde_impls {
             deserializer.deserialize_map(Visitor)
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Dictionary;
+    use std::collections::HashMap;
+
+
+    #[test]
+    fn from_hash_map_to_dict() {
+        
+        let dogs = HashMap::from([
+            ("Doge", "Shiba Inu"),
+            ("Cheems", "Shiba Inu"),
+            ("Walter", "Bull Terrier"),
+            ("Perro", "Golden Retriever"),
+        ]);
+        let dict: Dictionary = dogs.into_iter().collect();
+        assert_eq!(dict.get("Doge").and_then(|v| v.as_string()), Some("Shiba Inu"));
+        assert_eq!(dict.get("Cheems").and_then(|v| v.as_string()), Some("Shiba Inu"));
+        assert_eq!(dict.get("Walter").and_then(|v| v.as_string()), Some("Bull Terrier"));
+        assert_eq!(dict.get("Perro").and_then(|v| v.as_string()), Some("Golden Retriever"));
+    }
+
 }


### PR DESCRIPTION
This pull request implements

```rust
impl<K: Into<String>, V: Into<Value>> FromIterator<(K, V)> for Dictionary
```

So one can do: 
```rust
let dict: Dictionary = hash_map.into_iter().collect();
```
It adds the proper tests to verify everything works.

Closes #63 
