### PR TITLE
WIP: Use quick-xml instead of xml-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [features]
 default = ["serde"]
+quick-xml = ["quick_xml"]
 enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
@@ -20,6 +21,7 @@ time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"
 xml_rs = { package = "xml-rs", version = "0.8.2" }
+quick_xml = { package = "quick-xml", version = "0.22.0", optional = true }
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ pub(crate) enum ErrorKind {
     Serde(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum FilePosition {
     LineColumn(u64, u64),
     Offset(u64),

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -814,6 +814,15 @@ fn dictionary_deserialize_dictionary_in_struct() {
 }
 
 #[test]
+fn empty_array_and_dictionary() {
+    #[derive(Serialize)]
+    struct Empty {
+        vec: Vec<String>,
+        map: BTreeMap<String, String>,
+    }
+}
+
+#[test]
 fn dictionary_serialize_xml() {
     // Dictionary to be embedded in dict, below.
     let mut inner_dict = Dictionary::new();
@@ -874,6 +883,34 @@ fn dictionary_serialize_xml() {
 \t<true/>
 \t<key>AFalseBoolean</key>
 \t<false/>
+</dict>
+</plist>";
+
+    assert_eq!(xml, comparison);
+}
+
+#[test]
+fn empty_array_and_dictionary_serialize_to_xml() {
+    #[derive(Serialize, Default)]
+    struct Empty {
+        vec: Vec<String>,
+        map: BTreeMap<String, String>,
+    }
+
+    // Serialize dictionary as an XML plist.
+    let mut buf = Cursor::new(Vec::new());
+    crate::to_writer_xml(&mut buf, &Empty::default()).unwrap();
+    let buf = buf.into_inner();
+    let xml = std::str::from_utf8(&buf).unwrap();
+
+    let comparison = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+\t<key>vec</key>
+\t<array/>
+\t<key>map</key>
+\t<dict/>
 </dict>
 </plist>";
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -6,8 +6,15 @@ pub use self::binary_reader::BinaryReader;
 mod binary_writer;
 pub use self::binary_writer::BinaryWriter;
 
+#[cfg(not(feature = "quick-xml"))]
 mod xml_reader;
+#[cfg(not(feature = "quick-xml"))]
 pub use self::xml_reader::XmlReader;
+
+#[cfg(feature = "quick-xml")]
+mod quick_xml_reader;
+#[cfg(feature = "quick-xml")]
+pub use self::quick_xml_reader::XmlReader;
 
 mod xml_writer;
 pub use self::xml_writer::XmlWriter;

--- a/src/stream/quick_xml_reader.rs
+++ b/src/stream/quick_xml_reader.rs
@@ -204,7 +204,9 @@ impl<R: Read> ReaderState<R> {
                     // Check the corrent element is being closed
                     match self.element_stack.pop() {
                         Some(open_name) if name.local_name() == open_name.as_ref() => {}
-                        Some(_open_name) => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
+                        Some(_open_name) => {
+                            return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
+                        }
                         None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
                     }
 
@@ -215,7 +217,9 @@ impl<R: Read> ReaderState<R> {
                 }
                 XmlEvent::Eof if self.element_stack.is_empty() => return Ok(None),
                 XmlEvent::Eof => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
-                XmlEvent::Text(_) => return Err(self.with_pos(ErrorKind::UnexpectedXmlCharactersExpectedElement)),
+                XmlEvent::Text(_) => {
+                    return Err(self.with_pos(ErrorKind::UnexpectedXmlCharactersExpectedElement))
+                }
                 XmlEvent::PI(_)
                 | XmlEvent::Decl(_)
                 | XmlEvent::DocType(_)

--- a/src/stream/quick_xml_reader.rs
+++ b/src/stream/quick_xml_reader.rs
@@ -1,0 +1,324 @@
+use base64;
+use std::{
+    io::{self, Read, BufReader},
+    str::FromStr,
+};
+use quick_xml::{
+    Reader as EventReader,
+    events::Event as XmlEvent,
+    Error as XmlReaderError,
+};
+
+use crate::{
+    error::{Error, ErrorKind, FilePosition},
+    stream::{Event, OwnedEvent},
+    Date, Integer,
+};
+
+mod xml_rs_stubs {
+    /// Checks whether the given character is a white space character (`S`)
+    /// as is defined by XML 1.1 specification, [section 2.3][1].
+    ///
+    /// [1]: http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-common-syn
+    pub fn is_whitespace_char(c: char) -> bool {
+        match c {
+            '\x20' | '\x09' | '\x0d' | '\x0a' => true,
+            _ => false
+        }
+    }
+
+    /// Checks whether the given string is compound only by white space
+    /// characters (`S`) using the previous is_whitespace_char to check
+    /// all characters of this string
+    pub fn is_whitespace_str(s: &str) -> bool {
+        s.chars().all(is_whitespace_char)
+    }
+}
+
+use xml_rs_stubs::is_whitespace_str;
+
+pub struct XmlReader<R: Read> {
+    buffer: Vec<u8>,
+    xml_reader: EventReader<BufReader<R>>,
+    closed_element: Option<Box<[u8]>>,
+    element_stack: Vec<Box<[u8]>>,
+    finished: bool,
+}
+
+impl<R: Read> XmlReader<R> {
+    pub fn new(reader: R) -> XmlReader<R> {
+        // let config = ParserConfig::new()
+        //     .trim_whitespace(false)
+        //     .whitespace_to_characters(true)
+        //     .cdata_to_characters(true)
+        //     .ignore_comments(true)
+        //     .coalesce_characters(true);
+
+        let mut xml_reader = EventReader::from_reader(BufReader::new(reader));
+        xml_reader.trim_text(true);
+
+        XmlReader {
+            buffer: Vec::new(),
+            xml_reader,
+            closed_element: None,
+            element_stack: Vec::new(),
+            finished: false,
+        }
+    }
+
+    fn read_content(&mut self) -> Result<String, Error> {
+        loop {
+            match self.xml_reader.read_event(&mut self.buffer) {
+                Ok(XmlEvent::Text(s)) => {
+                    return String::from_utf8(s.unescaped().unwrap().to_vec())
+                        .map_err(|_| ErrorKind::InvalidUtf8String.without_position())
+                },
+                Ok(XmlEvent::End(element)) => {
+                    self.closed_element = Some(element.local_name().to_owned().into_boxed_slice());
+                    return Ok("".to_owned());
+                }
+                Ok(XmlEvent::Eof) => {
+                    return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
+                }
+                Ok(XmlEvent::Start(_)) => {
+                    return Err(self.with_pos(ErrorKind::UnexpectedXmlOpeningTag));
+                }
+                Ok(XmlEvent::PI(_)) => (),
+                // Ok(XmlEvent::StartDocument { .. })
+                // | Ok(XmlEvent::CData(_))
+                // | Ok(XmlEvent::Comment(_))
+                // | Ok(XmlEvent::Whitespace(_)) => {
+                Ok(_) => {
+                    unreachable!("parser does not output CData, Comment or Whitespace events");
+                }
+                Err(err) => return Err(from_xml_error(err)),
+            }
+        }
+    }
+
+    // fn next_event(&mut self) -> Result<XmlEvent, XmlReaderError> {
+    //     self.xml_reader.read_event(&mut buffer)
+    // }
+
+    fn read_next(&mut self) -> Result<Option<OwnedEvent>, Error> {
+        loop {
+            if let Some(closed_name) = self.closed_element.take() {
+                // Ok(XmlEvent::EndElement { name, .. }) => {
+                    // Check the corrent element is being closed
+                match self.element_stack.pop() {
+                    Some(ref open_name) if &closed_name == open_name => (),
+                    Some(ref _open_name) => {
+                        return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
+                    }
+                    None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
+                }
+
+                match closed_name.as_ref() {
+                    b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
+                    b"plist" | _ => (),
+                }
+                // }
+            }
+
+            match self.xml_reader.read_event(&mut self.buffer) {
+                // Ok(XmlEvent::StartDocument { .. }) => {}
+                Ok(XmlEvent::Start(name)) => {
+                    // Add the current element to the element stack
+                    self.element_stack.push(name.local_name().to_owned().into_boxed_slice());
+
+                    match name.local_name() {
+                        b"plist" => (),
+                        b"array" => return Ok(Some(Event::StartArray(None))),
+                        b"dict" => return Ok(Some(Event::StartDictionary(None))),
+                        b"key" => return Ok(Some(Event::String(self.read_content()?.into()))),
+                        b"data" => {
+                            let mut s = self.read_content()?;
+                            // Strip whitespace and line endings from input string
+                            s.retain(|c| !c.is_ascii_whitespace());
+                            let data = base64::decode(&s)
+                                .map_err(|_| self.with_pos(ErrorKind::InvalidDataString))?;
+                            return Ok(Some(Event::Data(data.into())));
+                        }
+                        b"date" => {
+                            let s = self.read_content()?;
+                            let date = Date::from_rfc3339(&s)
+                                .map_err(|()| self.with_pos(ErrorKind::InvalidDateString))?;
+                            return Ok(Some(Event::Date(date)));
+                        }
+                        b"integer" => {
+                            let s = self.read_content()?;
+                            match Integer::from_str(&s) {
+                                Ok(i) => return Ok(Some(Event::Integer(i))),
+                                Err(_) => {
+                                    return Err(self.with_pos(ErrorKind::InvalidIntegerString))
+                                }
+                            }
+                        }
+                        b"real" => {
+                            let s = self.read_content()?;
+                            match f64::from_str(&s) {
+                                Ok(f) => return Ok(Some(Event::Real(f))),
+                                Err(_) => return Err(self.with_pos(ErrorKind::InvalidRealString)),
+                            }
+                        }
+                        b"string" => return Ok(Some(Event::String(self.read_content()?.into()))),
+                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
+                    }
+                }
+                Ok(XmlEvent::Empty(name)) => {
+                    match name.local_name() {
+                        b"true" => return Ok(Some(Event::Boolean(true))),
+                        b"false" => return Ok(Some(Event::Boolean(false))),
+                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
+                    }
+                }
+                Ok(XmlEvent::End(name)) => {
+                    // Check the corrent element is being closed
+                    match self.element_stack.pop() {
+                        Some(ref open_name) if name.local_name() == open_name.as_ref() => (),
+                        Some(ref _open_name) => {
+                            return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
+                        }
+                        None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
+                    }
+
+                    match name.local_name() {
+                        b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
+                        b"plist" | _ => (),
+                    }
+                }
+                Ok(XmlEvent::Eof) => {
+                    if self.element_stack.is_empty() {
+                        return Ok(None);
+                    } else {
+                        return Err(self.with_pos(ErrorKind::UnclosedXmlElement));
+                    }
+                }
+                Ok(XmlEvent::Text(c)) => {
+                    // if !is_whitespace_str(&c) {
+                        return Err(
+                            self.with_pos(ErrorKind::UnexpectedXmlCharactersExpectedElement)
+                        );
+                    // }
+                }
+                Ok(XmlEvent::CData(_)) | Ok(XmlEvent::Comment(_)) /*| Ok(XmlEvent::Whitespace(_)) */ => {
+                    unreachable!("parser does not output CData, Comment or Whitespace events")
+                }
+                Ok(XmlEvent::PI(_)) => (),
+                Ok(XmlEvent::Decl(_)) | Ok(XmlEvent::DocType(_)) => (),
+                Err(err) => return Err(from_xml_error(err)),
+            }
+        }
+    }
+
+    fn with_pos(&self, kind: ErrorKind) -> Error {
+        kind.with_position(convert_xml_pos(self.xml_reader.buffer_position()))
+    }
+}
+
+impl<R: Read> Iterator for XmlReader<R> {
+    type Item = Result<OwnedEvent, Error>;
+
+    fn next(&mut self) -> Option<Result<OwnedEvent, Error>> {
+        if self.finished {
+            None
+        } else {
+            match self.read_next() {
+                Ok(Some(event)) => Some(Ok(event)),
+                Ok(None) => {
+                    self.finished = true;
+                    None
+                }
+                Err(err) => {
+                    self.finished = true;
+                    Some(Err(err))
+                }
+            }
+        }
+    }
+}
+
+fn convert_xml_pos(pos: usize) -> FilePosition {
+    // TODO: pos.row and pos.column counts from 0. what do we want to do?
+    FilePosition::LineColumn(0, pos as u64)
+}
+
+fn from_xml_error(err: XmlReaderError) -> Error {
+    let kind = match err {
+        XmlReaderError::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
+            ErrorKind::UnexpectedEof
+        }
+        XmlReaderError::Io(err) => {
+            let err = if let Some(code) = err.raw_os_error() {
+                io::Error::from_raw_os_error(code)
+            } else {
+                io::Error::new(err.kind(), err.to_string())
+            };
+            ErrorKind::Io(err)
+        }
+        // XmlReaderError::Syntax(_) => ErrorKind::InvalidXmlSyntax,
+        XmlReaderError::UnexpectedEof(_) => ErrorKind::UnexpectedEof,
+        XmlReaderError::Utf8(_) => ErrorKind::InvalidXmlUtf8,
+        _ => ErrorKind::InvalidXmlSyntax,
+    };
+
+    kind.with_position(convert_xml_pos(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, path::Path};
+
+    use super::*;
+    use crate::stream::Event::{self, *};
+
+    #[test]
+    fn streaming_parser() {
+        let reader = File::open(&Path::new("./tests/data/xml.plist")).unwrap();
+        let streaming_parser = XmlReader::new(reader);
+        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
+
+        let comparison = &[
+            StartDictionary(None),
+            String("Author".into()),
+            String("William Shakespeare".into()),
+            String("Lines".into()),
+            StartArray(None),
+            String("It is a tale told by an idiot,".into()),
+            String("Full of sound and fury, signifying nothing.".into()),
+            EndCollection,
+            String("Death".into()),
+            Integer(1564.into()),
+            String("Height".into()),
+            Real(1.60),
+            String("Data".into()),
+            Data(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0].into()),
+            String("Birthdate".into()),
+            Date(super::Date::from_rfc3339("1981-05-16T11:32:06Z").unwrap()),
+            String("Blank".into()),
+            String("".into()),
+            String("BiggestNumber".into()),
+            Integer(18446744073709551615u64.into()),
+            String("SmallestNumber".into()),
+            Integer((-9223372036854775808i64).into()),
+            String("HexademicalNumber".into()),
+            Integer(0xdead_beef_u64.into()),
+            String("IsTrue".into()),
+            Boolean(true),
+            String("IsNotFalse".into()),
+            Boolean(false),
+            EndCollection,
+        ];
+
+        assert_eq!(events, comparison);
+    }
+
+    #[test]
+    fn bad_data() {
+        let reader = File::open(&Path::new("./tests/data/xml_error.plist")).unwrap();
+        let streaming_parser = XmlReader::new(reader);
+        let events: Vec<_> = streaming_parser.collect();
+
+        assert!(events.last().unwrap().is_err());
+    }
+}

--- a/src/stream/quick_xml_reader.rs
+++ b/src/stream/quick_xml_reader.rs
@@ -169,6 +169,20 @@ impl<R: Read> XmlReader<R> {
                     match name.local_name() {
                         b"true" => return Ok(Some(Event::Boolean(true))),
                         b"false" => return Ok(Some(Event::Boolean(false))),
+
+                        b"array" | b"dict" => {
+                            let owned_name = name.local_name().to_owned().into_boxed_slice();
+                            // Open and immediately close a collection element
+                            self.element_stack.push(owned_name.clone());
+                            self.closed_element = Some(owned_name);
+
+                            match name.local_name() {
+                                b"array" => return Ok(Some(Event::StartArray(None))),
+                                b"dict" => return Ok(Some(Event::StartDictionary(None))),
+                                _ => unreachable!(),
+                            }
+                        },
+
                         _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
                     }
                 }

--- a/src/stream/quick_xml_reader.rs
+++ b/src/stream/quick_xml_reader.rs
@@ -1,13 +1,5 @@
-use base64;
-use std::{
-    io::{self, Read, BufReader},
-    str::FromStr,
-};
-use quick_xml::{
-    Reader as EventReader,
-    events::Event as XmlEvent,
-    Error as XmlReaderError,
-};
+use quick_xml::{events::Event as XmlEvent, Error as XmlReaderError, Reader as EventReader};
+use std::io::{self, BufReader, Read};
 
 use crate::{
     error::{Error, ErrorKind, FilePosition},
@@ -15,250 +7,52 @@ use crate::{
     Date, Integer,
 };
 
-mod xml_rs_stubs {
-    /// Checks whether the given character is a white space character (`S`)
-    /// as is defined by XML 1.1 specification, [section 2.3][1].
-    ///
-    /// [1]: http://www.w3.org/TR/2006/REC-xml11-20060816/#sec-common-syn
-    pub fn is_whitespace_char(c: char) -> bool {
-        match c {
-            '\x20' | '\x09' | '\x0d' | '\x0a' => true,
-            _ => false
-        }
-    }
+#[derive(Clone, PartialEq, Eq)]
+struct ElmName(Box<[u8]>);
 
-    /// Checks whether the given string is compound only by white space
-    /// characters (`S`) using the previous is_whitespace_char to check
-    /// all characters of this string
-    pub fn is_whitespace_str(s: &str) -> bool {
-        s.chars().all(is_whitespace_char)
+impl From<&[u8]> for ElmName {
+    fn from(bytes: &[u8]) -> Self {
+        ElmName(Box::from(bytes))
     }
 }
 
-use xml_rs_stubs::is_whitespace_str;
+impl AsRef<[u8]> for ElmName {
+    fn as_ref(&self) -> &[u8] {
+        &*self.0
+    }
+}
 
 pub struct XmlReader<R: Read> {
     buffer: Vec<u8>,
-    xml_reader: EventReader<BufReader<R>>,
-    closed_element: Option<Box<[u8]>>,
-    element_stack: Vec<Box<[u8]>>,
     finished: bool,
+    state: ReaderState<R>,
+}
+
+struct ReaderState<R: Read> {
+    xml_reader: EventReader<BufReader<R>>,
+    closed_element: Option<ElmName>,
+    element_stack: Vec<ElmName>,
 }
 
 impl<R: Read> XmlReader<R> {
     pub fn new(reader: R) -> XmlReader<R> {
-        // let config = ParserConfig::new()
-        //     .trim_whitespace(false)
-        //     .whitespace_to_characters(true)
-        //     .cdata_to_characters(true)
-        //     .ignore_comments(true)
-        //     .coalesce_characters(true);
-
         let mut xml_reader = EventReader::from_reader(BufReader::new(reader));
         xml_reader.trim_text(true);
 
         XmlReader {
             buffer: Vec::new(),
-            xml_reader,
-            closed_element: None,
-            element_stack: Vec::new(),
             finished: false,
-        }
-    }
-
-    fn read_content(&mut self) -> Result<String, Error> {
-        loop {
-            match self.xml_reader.read_event(&mut self.buffer) {
-                Ok(XmlEvent::Text(s)) => {
-                    return String::from_utf8(s.unescaped().unwrap().to_vec())
-                        .map_err(|_| ErrorKind::InvalidUtf8String.without_position())
-                },
-                Ok(XmlEvent::End(element)) => {
-                    self.closed_element = Some(element.local_name().to_owned().into_boxed_slice());
-                    return Ok("".to_owned());
-                }
-                Ok(XmlEvent::Eof) => {
-                    return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
-                }
-                Ok(XmlEvent::Start(_)) => {
-                    return Err(self.with_pos(ErrorKind::UnexpectedXmlOpeningTag));
-                }
-                Ok(XmlEvent::PI(_)) => (),
-                // Ok(XmlEvent::StartDocument { .. })
-                // | Ok(XmlEvent::CData(_))
-                // | Ok(XmlEvent::Comment(_))
-                // | Ok(XmlEvent::Whitespace(_)) => {
-                Ok(_) => {
-                    unreachable!("parser does not output CData, Comment or Whitespace events");
-                }
-                Err(err) => return Err(from_xml_error(err)),
-            }
-        }
-    }
-
-    // fn next_event(&mut self) -> Result<XmlEvent, XmlReaderError> {
-    //     self.xml_reader.read_event(&mut buffer)
-    // }
-
-    fn read_next(&mut self) -> Result<Option<OwnedEvent>, Error> {
-        loop {
-            if let Some(closed_name) = self.closed_element.take() {
-                // Ok(XmlEvent::EndElement { name, .. }) => {
-                    // Check the corrent element is being closed
-                match self.element_stack.pop() {
-                    Some(ref open_name) if &closed_name == open_name => (),
-                    Some(ref _open_name) => {
-                        return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
-                    }
-                    None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
-                }
-
-                match closed_name.as_ref() {
-                    b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
-                    b"plist" | _ => (),
-                }
-                // }
-            }
-
-            match self.xml_reader.read_event(&mut self.buffer) {
-                // Ok(XmlEvent::StartDocument { .. }) => {}
-                Ok(XmlEvent::Start(name)) => {
-                    // Add the current element to the element stack
-                    self.element_stack.push(name.local_name().to_owned().into_boxed_slice());
-
-                    match name.local_name() {
-                        b"plist" => (),
-                        b"array" => return Ok(Some(Event::StartArray(None))),
-                        b"dict" => return Ok(Some(Event::StartDictionary(None))),
-                        b"key" => return Ok(Some(Event::String(self.read_content()?.into()))),
-                        b"data" => {
-                            let mut s = self.read_content()?;
-                            // Strip whitespace and line endings from input string
-                            s.retain(|c| !c.is_ascii_whitespace());
-                            let data = base64::decode(&s)
-                                .map_err(|_| self.with_pos(ErrorKind::InvalidDataString))?;
-                            return Ok(Some(Event::Data(data.into())));
-                        }
-                        b"date" => {
-                            let s = self.read_content()?;
-                            let date = Date::from_rfc3339(&s)
-                                .map_err(|()| self.with_pos(ErrorKind::InvalidDateString))?;
-                            return Ok(Some(Event::Date(date)));
-                        }
-                        b"integer" => {
-                            let s = self.read_content()?;
-                            match Integer::from_str(&s) {
-                                Ok(i) => return Ok(Some(Event::Integer(i))),
-                                Err(_) => {
-                                    return Err(self.with_pos(ErrorKind::InvalidIntegerString))
-                                }
-                            }
-                        }
-                        b"real" => {
-                            let s = self.read_content()?;
-                            match f64::from_str(&s) {
-                                Ok(f) => return Ok(Some(Event::Real(f))),
-                                Err(_) => return Err(self.with_pos(ErrorKind::InvalidRealString)),
-                            }
-                        }
-                        b"string" => return Ok(Some(Event::String(self.read_content()?.into()))),
-                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
-                    }
-                }
-                Ok(XmlEvent::Empty(name)) => {
-                    match name.local_name() {
-                        b"true" => return Ok(Some(Event::Boolean(true))),
-                        b"false" => return Ok(Some(Event::Boolean(false))),
-
-                        b"array" | b"dict" => {
-                            let owned_name = name.local_name().to_owned().into_boxed_slice();
-                            // Open and immediately close a collection element
-                            self.element_stack.push(owned_name.clone());
-                            self.closed_element = Some(owned_name);
-
-                            match name.local_name() {
-                                b"array" => return Ok(Some(Event::StartArray(None))),
-                                b"dict" => return Ok(Some(Event::StartDictionary(None))),
-                                _ => unreachable!(),
-                            }
-                        },
-
-                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
-                    }
-                }
-                Ok(XmlEvent::End(name)) => {
-                    // Check the corrent element is being closed
-                    match self.element_stack.pop() {
-                        Some(ref open_name) if name.local_name() == open_name.as_ref() => (),
-                        Some(ref _open_name) => {
-                            return Err(self.with_pos(ErrorKind::UnclosedXmlElement))
-                        }
-                        None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
-                    }
-
-                    match name.local_name() {
-                        b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
-                        b"plist" | _ => (),
-                    }
-                }
-                Ok(XmlEvent::Eof) => {
-                    if self.element_stack.is_empty() {
-                        return Ok(None);
-                    } else {
-                        return Err(self.with_pos(ErrorKind::UnclosedXmlElement));
-                    }
-                }
-                Ok(XmlEvent::Text(c)) => {
-                    // if !is_whitespace_str(&c) {
-                        return Err(
-                            self.with_pos(ErrorKind::UnexpectedXmlCharactersExpectedElement)
-                        );
-                    // }
-                }
-                Ok(XmlEvent::CData(_)) | Ok(XmlEvent::Comment(_)) /*| Ok(XmlEvent::Whitespace(_)) */ => {
-                    unreachable!("parser does not output CData, Comment or Whitespace events")
-                }
-                Ok(XmlEvent::PI(_)) => (),
-                Ok(XmlEvent::Decl(_)) | Ok(XmlEvent::DocType(_)) => (),
-                Err(err) => return Err(from_xml_error(err)),
-            }
-        }
-    }
-
-    fn with_pos(&self, kind: ErrorKind) -> Error {
-        kind.with_position(convert_xml_pos(self.xml_reader.buffer_position()))
-    }
-}
-
-impl<R: Read> Iterator for XmlReader<R> {
-    type Item = Result<OwnedEvent, Error>;
-
-    fn next(&mut self) -> Option<Result<OwnedEvent, Error>> {
-        if self.finished {
-            None
-        } else {
-            match self.read_next() {
-                Ok(Some(event)) => Some(Ok(event)),
-                Ok(None) => {
-                    self.finished = true;
-                    None
-                }
-                Err(err) => {
-                    self.finished = true;
-                    Some(Err(err))
-                }
-            }
+            state: ReaderState {
+                xml_reader,
+                closed_element: None,
+                element_stack: Vec::new(),
+            },
         }
     }
 }
 
-fn convert_xml_pos(pos: usize) -> FilePosition {
-    // TODO: pos.row and pos.column counts from 0. what do we want to do?
-    FilePosition::LineColumn(0, pos as u64)
-}
-
-fn from_xml_error(err: XmlReaderError) -> Error {
-    let kind = match err {
+fn from_xml_error(err: XmlReaderError) -> ErrorKind {
+    match err {
         XmlReaderError::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
             ErrorKind::UnexpectedEof
         }
@@ -270,13 +64,189 @@ fn from_xml_error(err: XmlReaderError) -> Error {
             };
             ErrorKind::Io(err)
         }
-        // XmlReaderError::Syntax(_) => ErrorKind::InvalidXmlSyntax,
         XmlReaderError::UnexpectedEof(_) => ErrorKind::UnexpectedEof,
         XmlReaderError::Utf8(_) => ErrorKind::InvalidXmlUtf8,
         _ => ErrorKind::InvalidXmlSyntax,
-    };
+    }
+}
 
-    kind.with_position(convert_xml_pos(0))
+impl<R: Read> ReaderState<R> {
+    fn xml_reader_pos(&self) -> FilePosition {
+        let pos = self.xml_reader.buffer_position();
+        FilePosition::Offset(pos as u64)
+    }
+
+    fn with_pos(&self, kind: ErrorKind) -> Error {
+        kind.with_position(self.xml_reader_pos())
+    }
+
+    fn read_xml_event<'buf>(&mut self, buffer: &'buf mut Vec<u8>) -> Result<XmlEvent<'buf>, Error> {
+        let event = self.xml_reader.read_event(buffer);
+        let pos = self.xml_reader_pos();
+        event.map_err(|err| from_xml_error(err).with_position(pos))
+    }
+
+    fn read_content(&mut self, buffer: &mut Vec<u8>) -> Result<String, Error> {
+        loop {
+            match self.read_xml_event(buffer)? {
+                XmlEvent::Text(text) => {
+                    let pos = self.xml_reader_pos();
+                    let unespcaped = text
+                        .unescaped()
+                        .map_err(|err| from_xml_error(err).with_position(pos))?;
+                    return String::from_utf8(unespcaped.to_vec())
+                        .map_err(|_| ErrorKind::InvalidUtf8String.with_position(pos));
+                }
+                XmlEvent::End(element) => {
+                    self.closed_element = Some(element.local_name().into());
+                    return Ok("".to_owned());
+                }
+                XmlEvent::Eof => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
+                XmlEvent::Start(_) => return Err(self.with_pos(ErrorKind::UnexpectedXmlOpeningTag)),
+                XmlEvent::PI(_)
+                | XmlEvent::Empty(_)
+                | XmlEvent::Comment(_)
+                | XmlEvent::CData(_)
+                | XmlEvent::Decl(_)
+                | XmlEvent::DocType(_) => {
+                    // skip
+                }
+            }
+        }
+    }
+
+    fn read_next(&mut self, buffer: &mut Vec<u8>) -> Result<Option<OwnedEvent>, Error> {
+        loop {
+            if let Some(closed_name) = self.closed_element.take() {
+                // Check the corrent element is being closed
+                match self.element_stack.pop() {
+                    Some(open_name) if closed_name == open_name => (),
+                    Some(_open_name) => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
+                    None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
+                }
+
+                match closed_name.as_ref() {
+                    b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
+                    b"plist" | _ => {}
+                }
+            }
+
+            match self.read_xml_event(buffer)? {
+                XmlEvent::Start(name) => {
+                    // Add the current element to the element stack
+                    self.element_stack.push(name.local_name().into());
+
+                    match name.local_name() {
+                        b"plist" => {}
+                        b"array" => return Ok(Some(Event::StartArray(None))),
+                        b"dict" => return Ok(Some(Event::StartDictionary(None))),
+                        b"key" => {
+                            return Ok(Some(Event::String(self.read_content(buffer)?.into())))
+                        }
+                        b"data" => {
+                            let mut encoded = self.read_content(buffer)?;
+                            // Strip whitespace and line endings from input string
+                            encoded.retain(|c| !c.is_ascii_whitespace());
+                            let data = base64::decode(&encoded)
+                                .map_err(|_| self.with_pos(ErrorKind::InvalidDataString))?;
+                            return Ok(Some(Event::Data(data.into())));
+                        }
+                        b"date" => {
+                            let s = self.read_content(buffer)?;
+                            let date = Date::from_rfc3339(&s)
+                                .map_err(|()| self.with_pos(ErrorKind::InvalidDateString))?;
+                            return Ok(Some(Event::Date(date)));
+                        }
+                        b"integer" => {
+                            let s = self.read_content(buffer)?;
+                            match Integer::from_str(&s) {
+                                Ok(i) => return Ok(Some(Event::Integer(i))),
+                                Err(_) => {
+                                    return Err(self.with_pos(ErrorKind::InvalidIntegerString))
+                                }
+                            }
+                        }
+                        b"real" => {
+                            let s = self.read_content(buffer)?;
+                            match s.parse() {
+                                Ok(f) => return Ok(Some(Event::Real(f))),
+                                Err(_) => return Err(self.with_pos(ErrorKind::InvalidRealString)),
+                            }
+                        }
+                        b"string" => {
+                            return Ok(Some(Event::String(self.read_content(buffer)?.into())))
+                        }
+                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
+                    }
+                }
+                XmlEvent::Empty(name) => {
+                    match name.local_name() {
+                        b"true" => return Ok(Some(Event::Boolean(true))),
+                        b"false" => return Ok(Some(Event::Boolean(false))),
+
+                        b"array" | b"dict" => {
+                            let owned_name = ElmName::from(name.local_name());
+                            // Open and immediately close a collection element
+                            self.element_stack.push(owned_name.clone());
+                            self.closed_element = Some(owned_name);
+
+                            match name.local_name() {
+                                b"array" => return Ok(Some(Event::StartArray(None))),
+                                b"dict" => return Ok(Some(Event::StartDictionary(None))),
+                                _ => unreachable!(),
+                            }
+                        }
+
+                        _ => return Err(self.with_pos(ErrorKind::UnknownXmlElement)),
+                    }
+                }
+                XmlEvent::End(name) => {
+                    // Check the corrent element is being closed
+                    match self.element_stack.pop() {
+                        Some(open_name) if name.local_name() == open_name.as_ref() => {}
+                        Some(_open_name) => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
+                        None => return Err(self.with_pos(ErrorKind::UnpairedXmlClosingTag)),
+                    }
+
+                    match name.local_name() {
+                        b"array" | b"dict" => return Ok(Some(Event::EndCollection)),
+                        b"plist" | _ => (),
+                    }
+                }
+                XmlEvent::Eof if self.element_stack.is_empty() => return Ok(None),
+                XmlEvent::Eof => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
+                XmlEvent::Text(_) => return Err(self.with_pos(ErrorKind::UnexpectedXmlCharactersExpectedElement)),
+                XmlEvent::PI(_)
+                | XmlEvent::Decl(_)
+                | XmlEvent::DocType(_)
+                | XmlEvent::CData(_)
+                | XmlEvent::Comment(_) => {
+                    // skip
+                }
+            }
+        }
+    }
+}
+
+impl<R: Read> Iterator for XmlReader<R> {
+    type Item = Result<OwnedEvent, Error>;
+
+    fn next(&mut self) -> Option<Result<OwnedEvent, Error>> {
+        if self.finished {
+            return None;
+        }
+        match self.state.read_next(&mut self.buffer) {
+            Ok(Some(event)) => Some(Ok(event)),
+            Ok(None) => {
+                self.finished = true;
+                None
+            }
+            Err(err) => {
+                self.finished = true;
+                Some(Err(err))
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/stream/quick_xml_writer.rs
+++ b/src/stream/quick_xml_writer.rs
@@ -1,0 +1,379 @@
+use quick_xml::{
+    events::{BytesEnd, BytesStart, BytesText, Event as XmlEvent},
+    Error as XmlWriterError, Writer as EventWriter,
+};
+use std::io::Write;
+
+use crate::{
+    error::{self, Error, ErrorKind, EventKind},
+    stream::{Writer, XmlWriteOptions},
+    Date, Integer, Uid,
+};
+
+static XML_PROLOGUE: &[u8] = br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+"#;
+
+#[derive(PartialEq)]
+enum Element {
+    Dictionary,
+    Array,
+}
+
+pub struct XmlWriter<W: Write> {
+    xml_writer: EventWriter<W>,
+    stack: Vec<Element>,
+    expecting_key: bool,
+    written_prologue: bool,
+}
+
+impl<W: Write> XmlWriter<W> {
+    pub fn new(writer: W) -> XmlWriter<W> {
+        let opts = XmlWriteOptions::default();
+        XmlWriter::new_with_options(writer, &opts)
+    }
+
+    pub fn new_with_options(writer: W, opts: &XmlWriteOptions) -> XmlWriter<W> {
+        let xml_writer = if opts.indent_amount == 0 {
+            EventWriter::new(writer)
+        } else {
+            EventWriter::new_with_indent(writer, opts.indent_char, opts.indent_amount)
+        };
+
+        XmlWriter {
+            xml_writer,
+            stack: Vec::new(),
+            expecting_key: false,
+            written_prologue: false,
+        }
+    }
+
+    fn write_element_and_value(&mut self, name: &str, value: &str) -> Result<(), Error> {
+        self.start_element(name)?;
+        self.write_value(value)?;
+        self.end_element(name)?;
+        Ok(())
+    }
+
+    fn start_element(&mut self, name: &str) -> Result<(), Error> {
+        self.xml_writer
+            .write_event(XmlEvent::Start(BytesStart::borrowed_name(name.as_bytes())))
+            .map_err(from_xml_error)?;
+        Ok(())
+    }
+
+    fn end_element(&mut self, name: &str) -> Result<(), Error> {
+        self.xml_writer
+            .write_event(XmlEvent::End(BytesEnd::borrowed(name.as_bytes())))
+            .map_err(from_xml_error)?;
+        Ok(())
+    }
+
+    fn write_value(&mut self, value: &str) -> Result<(), Error> {
+        self.xml_writer
+            .write_event(XmlEvent::Text(BytesText::from_plain_str(value)))
+            .map_err(from_xml_error)?;
+        Ok(())
+    }
+
+    pub fn into_inner(self) -> W {
+        self.xml_writer.into_inner()
+    }
+
+    fn write_prologue(&mut self) -> Result<(), Error> {
+        self.xml_writer
+            .inner()
+            .write_all(XML_PROLOGUE)
+            .map_err(error::from_io_without_position)
+    }
+
+    fn write_epilogue(&mut self) -> Result<(), Error> {
+        // We didn't tell the xml_writer about the <plist> tag so we'll skip telling it
+        // about the </plist> tag as well.
+        self.xml_writer
+            .inner()
+            .write_all(b"\n</plist>")
+            .map_err(error::from_io_without_position)?;
+        self.xml_writer
+            .inner()
+            .flush()
+            .map_err(error::from_io_without_position)
+    }
+
+    fn write_event<F: FnOnce(&mut Self) -> Result<(), Error>>(
+        &mut self,
+        f: F,
+    ) -> Result<(), Error> {
+        if !self.written_prologue {
+            self.write_prologue()?;
+            self.written_prologue = true;
+        }
+
+        f(self)?;
+
+        // If there are no more open tags then write the </plist> element
+        if self.stack.is_empty() {
+            self.write_epilogue()?;
+        }
+
+        Ok(())
+    }
+
+    fn write_value_event<F: FnOnce(&mut Self) -> Result<(), Error>>(
+        &mut self,
+        event_kind: EventKind,
+        f: F,
+    ) -> Result<(), Error> {
+        self.write_event(|this| {
+            if this.expecting_key {
+                return Err(ErrorKind::UnexpectedEventType {
+                    expected: EventKind::DictionaryKeyOrEndCollection,
+                    found: event_kind,
+                }
+                .without_position());
+            }
+            f(this)?;
+            this.expecting_key = this.stack.last() == Some(&Element::Dictionary);
+            Ok(())
+        })
+    }
+}
+
+impl<W: Write> Writer for XmlWriter<W> {
+    fn write_start_array(&mut self, _len: Option<u64>) -> Result<(), Error> {
+        self.write_value_event(EventKind::StartArray, |this| {
+            this.start_element("array")?;
+            this.stack.push(Element::Array);
+            Ok(())
+        })
+    }
+
+    fn write_start_dictionary(&mut self, _len: Option<u64>) -> Result<(), Error> {
+        self.write_value_event(EventKind::StartDictionary, |this| {
+            this.start_element("dict")?;
+            this.stack.push(Element::Dictionary);
+            Ok(())
+        })
+    }
+
+    fn write_end_collection(&mut self) -> Result<(), Error> {
+        self.write_event(|this| {
+            match (this.stack.pop(), this.expecting_key) {
+                (Some(Element::Dictionary), true) => {
+                    this.end_element("dict")?;
+                }
+                (Some(Element::Array), _) => {
+                    this.end_element("array")?;
+                }
+                (Some(Element::Dictionary), false) | (None, _) => {
+                    return Err(ErrorKind::UnexpectedEventType {
+                        expected: EventKind::ValueOrStartCollection,
+                        found: EventKind::EndCollection,
+                    }
+                    .without_position());
+                }
+            }
+            this.expecting_key = this.stack.last() == Some(&Element::Dictionary);
+            Ok(())
+        })
+    }
+
+    fn write_boolean(&mut self, value: bool) -> Result<(), Error> {
+        self.write_value_event(EventKind::Boolean, |this| {
+            let value = if value { "true" } else { "false" }.as_bytes();
+            this.xml_writer
+                .write_event(XmlEvent::Empty(BytesStart::borrowed_name(value)))
+                .map_err(from_xml_error)
+        })
+    }
+
+    fn write_data(&mut self, value: &[u8]) -> Result<(), Error> {
+        self.write_value_event(EventKind::Data, |this| {
+            let base64_data = base64_encode_plist(&value, this.stack.len());
+            this.write_element_and_value("data", &base64_data)
+        })
+    }
+
+    fn write_date(&mut self, value: Date) -> Result<(), Error> {
+        self.write_value_event(EventKind::Date, |this| {
+            this.write_element_and_value("date", &value.to_rfc3339())
+        })
+    }
+
+    fn write_integer(&mut self, value: Integer) -> Result<(), Error> {
+        self.write_value_event(EventKind::Integer, |this| {
+            this.write_element_and_value("integer", &value.to_string())
+        })
+    }
+
+    fn write_real(&mut self, value: f64) -> Result<(), Error> {
+        self.write_value_event(EventKind::Real, |this| {
+            this.write_element_and_value("real", &value.to_string())
+        })
+    }
+
+    fn write_string(&mut self, value: &str) -> Result<(), Error> {
+        self.write_event(|this| {
+            if this.expecting_key {
+                this.write_element_and_value("key", &*value)?;
+                this.expecting_key = false;
+            } else {
+                this.write_element_and_value("string", &*value)?;
+                this.expecting_key = this.stack.last() == Some(&Element::Dictionary);
+            }
+            Ok(())
+        })
+    }
+
+    fn write_uid(&mut self, _value: Uid) -> Result<(), Error> {
+        Err(ErrorKind::UidNotSupportedInXmlPlist.without_position())
+    }
+}
+
+pub(crate) fn from_xml_error(err: XmlWriterError) -> Error {
+    match err {
+        XmlWriterError::Io(err) => ErrorKind::Io(err).without_position(),
+        _ => unreachable!(),
+    }
+}
+
+fn base64_encode_plist(data: &[u8], indent: usize) -> String {
+    // XML plist data elements are always formatted by apple tools as
+    // <data>
+    // AAAA..AA (68 characters per line)
+    // </data>
+    // Allocate space for base 64 string and line endings up front
+    const LINE_LEN: usize = 68;
+    let mut line_ending = Vec::with_capacity(1 + indent);
+    line_ending.push(b'\n');
+    (0..indent).for_each(|_| line_ending.push(b'\t'));
+
+    // Find the max length of `data` encoded as a base 64 string with padding
+    let base64_max_string_len = data.len() * 4 / 3 + 4;
+
+    // Find the max length of the formatted base 64 string as: max length of the base 64 string
+    // + line endings and indents at the start of the string and after every line
+    let base64_max_string_len_with_formatting =
+        base64_max_string_len + (2 + base64_max_string_len / LINE_LEN) * line_ending.len();
+
+    let mut output = vec![0; base64_max_string_len_with_formatting];
+
+    // Start output with a line ending and indent
+    output[..line_ending.len()].copy_from_slice(&line_ending);
+
+    // Encode `data` as a base 64 string
+    let base64_string_len =
+        base64::encode_config_slice(data, base64::STANDARD, &mut output[line_ending.len()..]);
+
+    // Line wrap the base 64 encoded string
+    let line_wrap_len = line_wrap::line_wrap(
+        &mut output[line_ending.len()..],
+        base64_string_len,
+        LINE_LEN,
+        &line_wrap::SliceLineEnding::new(&line_ending),
+    );
+
+    // Add the final line ending and indent
+    output[line_ending.len() + base64_string_len + line_wrap_len..][..line_ending.len()]
+        .copy_from_slice(&line_ending);
+
+    // Ensure output is the correct length
+    output.truncate(base64_string_len + line_wrap_len + 2 * line_ending.len());
+    String::from_utf8(output).expect("base 64 string must be valid utf8")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::stream::Event;
+
+    #[test]
+    fn streaming_parser() {
+        let plist = &[
+            Event::StartDictionary(None),
+            Event::String("Author".into()),
+            Event::String("William Shakespeare".into()),
+            Event::String("Lines".into()),
+            Event::StartArray(None),
+            Event::String("It is a tale told by an idiot,".into()),
+            Event::String("Full of sound and fury, signifying nothing.".into()),
+            Event::Data((0..128).collect::<Vec<_>>().into()),
+            Event::EndCollection,
+            Event::String("Death".into()),
+            Event::Integer(1564.into()),
+            Event::String("Height".into()),
+            Event::Real(1.60),
+            Event::String("Data".into()),
+            Event::Data(vec![0, 0, 0, 190, 0, 0, 0, 3, 0, 0, 0, 30, 0, 0, 0].into()),
+            Event::String("Birthdate".into()),
+            Event::Date(super::Date::from_rfc3339("1981-05-16T11:32:06Z").unwrap()),
+            Event::String("Comment".into()),
+            Event::String("2 < 3".into()), // make sure characters are escaped
+            Event::String("BiggestNumber".into()),
+            Event::Integer(18446744073709551615u64.into()),
+            Event::String("SmallestNumber".into()),
+            Event::Integer((-9223372036854775808i64).into()),
+            Event::String("IsTrue".into()),
+            Event::Boolean(true),
+            Event::String("IsNotFalse".into()),
+            Event::Boolean(false),
+            Event::EndCollection,
+        ];
+
+        let mut cursor = Cursor::new(Vec::new());
+
+        {
+            let mut plist_w = XmlWriter::new(&mut cursor);
+
+            for item in plist {
+                plist_w.write(item).unwrap();
+            }
+        }
+
+        let comparison = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+\t<key>Author</key>
+\t<string>William Shakespeare</string>
+\t<key>Lines</key>
+\t<array>
+\t\t<string>It is a tale told by an idiot,</string>
+\t\t<string>Full of sound and fury, signifying nothing.</string>
+\t\t<data>
+\t\tAAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEy
+\t\tMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2Rl
+\t\tZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn8=
+\t\t</data>
+\t</array>
+\t<key>Death</key>
+\t<integer>1564</integer>
+\t<key>Height</key>
+\t<real>1.6</real>
+\t<key>Data</key>
+\t<data>
+\tAAAAvgAAAAMAAAAeAAAA
+\t</data>
+\t<key>Birthdate</key>
+\t<date>1981-05-16T11:32:06Z</date>
+\t<key>Comment</key>
+\t<string>2 &lt; 3</string>
+\t<key>BiggestNumber</key>
+\t<integer>18446744073709551615</integer>
+\t<key>SmallestNumber</key>
+\t<integer>-9223372036854775808</integer>
+\t<key>IsTrue</key>
+\t<true/>
+\t<key>IsNotFalse</key>
+\t<false/>
+</dict>
+</plist>";
+
+        let s = String::from_utf8(cursor.into_inner()).unwrap();
+
+        assert_eq!(s, comparison);
+    }
+}


### PR DESCRIPTION
Hi! This is a very quick-and-dirty experiment to see if the perf gains are worth it, if you'd be interested in this at all I'll gladly clean it up to what you think is a mergeable state.

I've tried using rust-plist for parsing void-linux package repositories which are about 15MB of xml-encoded plist, with the latest release from crates.io parsing that took roughly 2.4s, with this patch to rust-plist it only took 0.23s which is much closer to what xbps-query (the void-linux cli tool which queries the repository) takes (xbps takes about 0.3s but i think it's doing extra work, i didn't try to isolate the parsing).