### PR TITLE
Support writing a plist without the XML prolog and root element

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,9 @@ pub(crate) enum ErrorKind {
     UnexpectedEof,
     UnexpectedEndOfEventStream,
     UnexpectedEventType {
+        #[allow(dead_code)]
         expected: EventKind,
+        #[allow(dead_code)]
         found: EventKind,
     },
 
@@ -55,6 +57,7 @@ pub(crate) enum ErrorKind {
     UnknownObjectType(u8),
 
     Io(io::Error),
+    #[cfg(feature = "serde")]
     Serde(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@
 //! specify a tilde requirement e.g. `plist = "~1.0.3"` in you `Cargo.toml` so that the plist crate
 //! is not automatically updated to version 1.1.
 
+// Treat all warnings as errors.
+#![deny(warnings)]
+
 pub mod dictionary;
 
 #[cfg(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps")]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -87,6 +87,7 @@ enum StackItem<'a> {
 #[derive(Clone, Debug)]
 pub struct XmlWriteOptions {
     indent_str: Cow<'static, str>,
+    root_element: bool,
 }
 
 impl XmlWriteOptions {
@@ -99,12 +100,30 @@ impl XmlWriteOptions {
         self.indent_str = indent_str.into();
         self
     }
+
+    /// Selects whether to write the XML prologue, plist document type and root element.
+    ///
+    /// In other words the following:
+    /// ```xml
+    /// <?xml version="1.0" encoding="UTF-8"?>
+    /// <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    /// <plist version="1.0">
+    /// ...
+    /// </plist>
+    /// ```
+    ///
+    /// The default is `true`.
+    pub fn root_element(mut self, write_root: bool) -> Self {
+        self.root_element = write_root;
+        self
+    }
 }
 
 impl Default for XmlWriteOptions {
     fn default() -> Self {
         XmlWriteOptions {
             indent_str: Cow::Borrowed("\t"),
+            root_element: true,
         }
     }
 }

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -35,6 +35,7 @@ pub struct XmlWriter<W: Write> {
 }
 
 impl<W: Write> XmlWriter<W> {
+    #[cfg(fearure = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
     pub fn new(writer: W) -> XmlWriter<W> {
         let opts = XmlWriteOptions::default();
         XmlWriter::new_with_options(writer, &opts)
@@ -60,6 +61,11 @@ impl<W: Write> XmlWriter<W> {
             expecting_key: false,
             empty_namespace: Namespace::empty(),
         }
+    }
+
+    #[cfg(feature="enable_unstable_features_that_may_break_with_minor_version_bumps")]
+    pub fn into_inner(self) -> W {
+        self.xml_writer.into_inner()
     }
 
     fn write_element_and_value(&mut self, name: &str, value: &str) -> Result<(), Error> {
@@ -94,10 +100,6 @@ impl<W: Write> XmlWriter<W> {
             .write(XmlEvent::Characters(value))
             .map_err(from_xml_error)?;
         Ok(())
-    }
-
-    pub fn into_inner(self) -> W {
-        self.xml_writer.into_inner()
     }
 
     fn write_event<F: FnOnce(&mut Self) -> Result<(), Error>>(


### PR DESCRIPTION
This is configured by the `XmlWriteOptions::root_element` option.

Closes #80.