### PR TITLE
Port from xml-rs to quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.13.0"
 time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"
-xml_rs = { package = "xml-rs", version = "0.8.2" }
+quick_xml = { package = "quick-xml", version = "0.22.0" }
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,6 @@ pub(crate) enum ErrorKind {
 
     // Xml format-specific errors
     UnclosedXmlElement,
-    UnpairedXmlClosingTag,
     UnexpectedXmlCharactersExpectedElement,
     UnexpectedXmlOpeningTag,
     UnknownXmlElement,
@@ -61,11 +60,8 @@ pub(crate) enum ErrorKind {
     Serde(String),
 }
 
-#[derive(Debug)]
-pub(crate) enum FilePosition {
-    LineColumn(u64, u64),
-    Offset(u64),
-}
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FilePosition(pub(crate) u64);
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub(crate) enum EventKind {
@@ -141,14 +137,7 @@ impl fmt::Display for Error {
 
 impl fmt::Display for FilePosition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            FilePosition::LineColumn(line, column) => {
-                write!(f, "line {}, column {}", line, column)
-            }
-            FilePosition::Offset(offset) => {
-                write!(f, "offset {}", offset)
-            }
-        }
+        write!(f, "offset {}", self.0)
     }
 }
 
@@ -160,7 +149,7 @@ impl From<InvalidXmlDate> for Error {
 
 impl ErrorKind {
     pub fn with_byte_offset(self, offset: u64) -> Error {
-        self.with_position(FilePosition::Offset(offset))
+        self.with_position(FilePosition(offset))
     }
 
     pub fn with_position(self, pos: FilePosition) -> Error {

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -862,7 +862,9 @@ fn dictionary_serialize_xml() {
 \t\t<key>FirstKey</key>
 \t\t<string>FirstValue</string>
 \t\t<key>SecondKey</key>
-\t\t<data>\n\t\tChQeKA==\n\t\t</data>
+\t\t<data>
+\t\tChQeKA==
+\t\t</data>
 \t\t<key>ThirdKey</key>
 \t\t<real>1.234</real>
 \t\t<key>FourthKey</key>
@@ -874,6 +876,34 @@ fn dictionary_serialize_xml() {
 \t<true/>
 \t<key>AFalseBoolean</key>
 \t<false/>
+</dict>
+</plist>";
+
+    assert_eq!(xml, comparison);
+}
+
+#[test]
+fn empty_array_and_dictionary_serialize_to_xml() {
+    #[derive(Serialize, Default)]
+    struct Empty {
+        vec: Vec<String>,
+        map: BTreeMap<String, String>,
+    }
+
+    // Serialize dictionary as an XML plist.
+    let mut buf = Cursor::new(Vec::new());
+    crate::to_writer_xml(&mut buf, &Empty::default()).unwrap();
+    let buf = buf.into_inner();
+    let xml = std::str::from_utf8(&buf).unwrap();
+
+    let comparison = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+\t<key>vec</key>
+\t<array/>
+\t<key>map</key>
+\t<dict/>
 </dict>
 </plist>";
 

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -36,7 +36,7 @@ enum PendingCollection {
 }
 
 impl<W: Write> XmlWriter<W> {
-    #[cfg(fearure = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
+    #[cfg(feature = "enable_unstable_features_that_may_break_with_minor_version_bumps")]
     pub fn new(writer: W) -> XmlWriter<W> {
         let opts = XmlWriteOptions::default();
         XmlWriter::new_with_options(writer, &opts)


### PR DESCRIPTION
Follow-up from #78. Things that happened since:
 - rebased this on the current changes on master
 - dropped the quick-xml impl into where the xml-rs one used to be, instead of offering quick-xml as a feature
 - fixed up the issue with pending collections
 - fixed a whole lot of clippy issues while I was at it

Thanks to @pr2502 for doing the heavy lifting here, most stuff was already in pretty good shape so I mostly just moved stuff around and did a few little touch-ups here and there.