### PR TITLE
Bump base64 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["serde"]
 enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.21.0"
 time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as base64_standard, Engine};
 use quick_xml::{events::Event as XmlEvent, Error as XmlReaderError, Reader as EventReader};
 use std::io::{self, BufReader, Read};
 
@@ -138,7 +139,8 @@ impl<R: Read> ReaderState<R> {
                             let mut encoded = self.read_content(buffer)?;
                             // Strip whitespace and line endings from input string
                             encoded.retain(|c| !c.is_ascii_whitespace());
-                            let data = base64::decode(&encoded)
+                            let data = base64_standard
+                                .decode(&encoded)
                                 .map_err(|_| self.with_pos(ErrorKind::InvalidDataString))?;
                             return Ok(Some(Event::Data(data.into())));
                         }

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as base64_standard, Engine};
 use quick_xml::{
     events::{BytesEnd, BytesStart, BytesText, Event as XmlEvent},
     Error as XmlWriterError, Writer as EventWriter,
@@ -307,8 +308,9 @@ fn base64_encode_plist(data: &[u8], indent: usize) -> String {
     output[..line_ending.len()].copy_from_slice(&line_ending);
 
     // Encode `data` as a base 64 string
-    let base64_string_len =
-        base64::encode_config_slice(data, base64::STANDARD, &mut output[line_ending.len()..]);
+    let base64_string_len = base64_standard
+        .encode_slice(data, &mut output[line_ending.len()..])
+        .expect("encoding slice fits base64 buffer");
 
     // Line wrap the base 64 encoded string
     let line_wrap_len = line_wrap::line_wrap(


### PR DESCRIPTION
Encoding could've panic'd before, so I kept the same behaviour but with a proper message.