### PR TITLE
Fixup method name in docs

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -100,7 +100,7 @@ impl XmlWriteOptions {
     ///
     /// Since replacing `xml-rs` with `quick-xml`, the indent string has to consist of a single
     /// repeating ascii character. This is a backwards compatibility function, prefer using
-    /// `XmlWriteOptions::with_indent`.
+    /// [`XmlWriteOptions::indent`].
     #[deprecated(since = "1.4.0", note = "please use `with_indent` instead")]
     pub fn indent_string(self, indent_str: impl Into<Cow<'static, str>>) -> Self {
         let indent_str = indent_str.into();


### PR DESCRIPTION
Slightly related: I find it useful to set `#![deny(rustdoc::broken_intra_doc_links)]` in the crate root, and then have a step in CI that runs `cargo doc --document-private-items`, which helps catch this sort of thing sometimes. 🤷 