### PR TITLE
Update to quick-xml 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.21.0"
 time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"
-quick_xml = { package = "quick-xml", version = "0.26.0" }
+quick_xml = { package = "quick-xml", version = "0.27.0" }
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -52,7 +52,10 @@ impl From<XmlReaderError> for ErrorKind {
             XmlReaderError::Io(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
                 ErrorKind::UnexpectedEof
             }
-            XmlReaderError::Io(err) => ErrorKind::Io(err),
+            XmlReaderError::Io(err) => match std::sync::Arc::try_unwrap(err) {
+                Ok(err) => ErrorKind::Io(err),
+                Err(err) => ErrorKind::Io(std::io::Error::from(err.kind())),
+            },
             XmlReaderError::UnexpectedEof(_) => ErrorKind::UnexpectedEof,
             XmlReaderError::NonDecodable(_) => ErrorKind::InvalidXmlUtf8,
             _ => ErrorKind::InvalidXmlSyntax,

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -277,7 +277,11 @@ impl<W: Write> Writer for XmlWriter<W> {
 impl From<XmlWriterError> for Error {
     fn from(err: XmlWriterError) -> Self {
         match err {
-            XmlWriterError::Io(err) => ErrorKind::Io(err).without_position(),
+            XmlWriterError::Io(err) => match std::sync::Arc::try_unwrap(err) {
+                Ok(err) => ErrorKind::Io(err),
+                Err(err) => ErrorKind::Io(std::io::Error::from(err.kind())),
+            }
+            .without_position(),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
This has one somewhat-annoying change: io::Errors that are generated by quick-xml are now wrapped in an Arc, which ends up polluting our own error type, and is a (minorly) breaking API change. I'm not sure if there is a better approach...