### PR TITLE
Some improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,11 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.21.0"
-time = { version = "0.3.3", features = ["parsing", "formatting"] }
-indexmap = "1.0.2"
+time = { version = "0.3.20", features = ["parsing", "formatting"] }
+indexmap = "1.9.3"
 line-wrap = "0.1.1"
-quick_xml = { package = "quick-xml", version = "0.28.0" }
-serde = { version = "1.0.2", optional = true }
+quick-xml = "0.28.1"
+serde = { version = "1.0.159", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_derive = { version = "1.0.2" }
-serde_yaml = "0.8.21"
+serde_yaml = "0.9.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.21.0"
-time = { version = "0.3.20", features = ["parsing", "formatting"] }
-indexmap = "1.9.3"
+time = { version = "0.3.3", features = ["parsing", "formatting"] }
+indexmap = "1.0.2"
 line-wrap = "0.1.1"
-quick-xml = "0.28.1"
-serde = { version = "1.0.159", features = ["derive"], optional = true }
+quick_xml = { package = "quick-xml", version = "0.28.0" }
+serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
-serde_yaml = "0.9.19"
+serde_derive = { version = "1.0.2" }
+serde_yaml = "0.8.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ base64 = "0.21.0"
 time = { version = "0.3.3", features = ["parsing", "formatting"] }
 indexmap = "1.0.2"
 line-wrap = "0.1.1"
-quick_xml = { package = "quick-xml", version = "0.28.0" }
-serde = { version = "1.0.2", optional = true }
+quick-xml = "0.28.0"
+serde = { version = "1.0.2", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_derive = { version = "1.0.2" }
 serde_yaml = "0.8.21"

--- a/fuzz/fuzz_targets/binary_reader.rs
+++ b/fuzz/fuzz_targets/binary_reader.rs
@@ -1,10 +1,9 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
-extern crate plist;
 
-use std::io::Cursor;
-use plist::Value;
+use libfuzzer_sys::fuzz_target;
 use plist::stream::BinaryReader;
+use plist::Value;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let cursor = Cursor::new(data);

--- a/fuzz/fuzz_targets/xml_reader.rs
+++ b/fuzz/fuzz_targets/xml_reader.rs
@@ -1,10 +1,9 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
-extern crate plist;
 
-use std::io::Cursor;
-use plist::Value;
+use libfuzzer_sys::fuzz_target;
 use plist::stream::XmlReader;
+use plist::Value;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let cursor = Cursor::new(data);

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,9 +7,7 @@ use std::fmt;
 /// ## Examples
 ///
 /// ```rust
-/// extern crate plist;
-/// #[macro_use]
-/// extern crate serde_derive;
+/// use serde::{Deserialize, Serialize};
 ///
 /// # fn main() {
 /// #[derive(Deserialize, Serialize)]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,10 @@
-use serde::de::{
-    self,
-    value::{MapAccessDeserializer, MapDeserializer},
-    IntoDeserializer,
+use serde::{
+    de::{
+        self,
+        value::{MapAccessDeserializer, MapDeserializer},
+        IntoDeserializer,
+    },
+    forward_to_deserialize_any,
 };
 use std::{
     borrow::Cow,

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -59,8 +59,8 @@ impl Dictionary {
     /// If the dictionary did have this key present, the value is updated, and the old value is
     /// returned.
     #[inline]
-    pub fn insert(&mut self, k: String, v: Value) -> Option<Value> {
-        self.map.insert(k, v)
+    pub fn insert(&mut self, k: impl Into<String>, v: impl Into<Value>) -> Option<Value> {
+        self.map.insert(k.into(), v.into())
     }
 
     /// Removes a key from the dictionary, returning the value at the key if the key was previously
@@ -638,7 +638,7 @@ pub mod serde_impls {
     use serde::{de, ser};
     use std::fmt;
 
-    use crate::Dictionary;
+    use crate::{Dictionary, Value};
 
     impl ser::Serialize for Dictionary {
         #[inline]
@@ -686,7 +686,7 @@ pub mod serde_impls {
                 {
                     let mut values = Dictionary::new();
 
-                    while let Some((key, value)) = visitor.next_entry()? {
+                    while let Some((key, value)) = visitor.next_entry::<String, Value>()? {
                         values.insert(key, value);
                     }
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -59,8 +59,8 @@ impl Dictionary {
     /// If the dictionary did have this key present, the value is updated, and the old value is
     /// returned.
     #[inline]
-    pub fn insert(&mut self, k: impl Into<String>, v: impl Into<Value>) -> Option<Value> {
-        self.map.insert(k.into(), v.into())
+    pub fn insert(&mut self, k: String, v: Value) -> Option<Value> {
+        self.map.insert(k, v)
     }
 
     /// Removes a key from the dictionary, returning the value at the key if the key was previously
@@ -638,7 +638,7 @@ pub mod serde_impls {
     use serde::{de, ser};
     use std::fmt;
 
-    use crate::{Dictionary, Value};
+    use crate::Dictionary;
 
     impl ser::Serialize for Dictionary {
         #[inline]
@@ -686,7 +686,7 @@ pub mod serde_impls {
                 {
                     let mut values = Dictionary::new();
 
-                    while let Some((key, value)) = visitor.next_entry::<String, Value>()? {
+                    while let Some((key, value)) = visitor.next_entry()? {
                         values.insert(key, value);
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,21 +11,13 @@
 //! plist = "1"
 //! ```
 //!
-//! And put this in your crate root:
-//!
-//! ```rust
-//! extern crate plist;
-//! ```
-//!
 //! ## Examples
 //!
 //! ### Using `serde`
 //!
 //! ```rust
-//! extern crate plist;
 //! # #[cfg(feature = "serde")]
-//! #[macro_use]
-//! extern crate serde_derive;
+//! use serde::{Deserialize, Serialize};
 //!
 //! # #[cfg(feature = "serde")]
 //! # fn main() {
@@ -102,9 +94,6 @@ pub use value::Value;
 
 // Optional serde module
 #[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-#[cfg(feature = "serde")]
 mod de;
 #[cfg(feature = "serde")]
 mod ser;
@@ -124,9 +113,6 @@ pub use self::{
     },
 };
 
-#[cfg(all(test, feature = "serde"))]
-#[macro_use]
-extern crate serde_derive;
 
 #[cfg(all(test, feature = "serde"))]
 mod serde_tests;

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -1,7 +1,4 @@
-use serde::{
-    de::{Deserialize, DeserializeOwned},
-    ser::Serialize,
-};
+use serde::{de::DeserializeOwned, ser, Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, fs::File, io::Cursor};
 
 use crate::{
@@ -92,7 +89,7 @@ fn new_deserializer<'event>(
 
 fn assert_roundtrip<T>(obj: T, comparison: Option<&[Event]>)
 where
-    T: Debug + DeserializeOwned + PartialEq + Serialize,
+    T: Debug + DeserializeOwned + PartialEq + ser::Serialize,
 {
     let mut se = new_serializer();
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -413,7 +413,7 @@ pub mod serde_impls {
                     V: MapAccess<'de>,
                 {
                     let mut values = Dictionary::new();
-                    while let Some((k, v)) = map.next_entry()? {
+                    while let Some((k, v)) = map.next_entry::<String, Value>()? {
                         values.insert(k, v);
                     }
                     Ok(Value::Dictionary(values))

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,7 +10,7 @@ use crate::{
     stream::{
         private, BinaryWriter, Event, Events, Reader, Writer, XmlReader, XmlWriteOptions, XmlWriter,
     },
-    u64_to_usize, Date, Dictionary, Integer, Uid,
+    u64_to_usize, Data, Date, Dictionary, Integer, Uid,
 };
 
 /// Represents any plist value.
@@ -638,8 +638,8 @@ impl<'a> From<&'a str> for Value {
     }
 }
 
-impl From<Vec<u8>> for Value {
-    fn from(value: Vec<u8>) -> Value {
+impl From<Data> for Value {
+    fn from(value: Data) -> Value {
         Value::Data(value)
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -640,7 +640,7 @@ impl<'a> From<&'a str> for Value {
 
 impl From<Data> for Value {
     fn from(value: Data) -> Value {
-        Value::Data(value)
+        Value::Data(value.into())
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -413,7 +413,7 @@ pub mod serde_impls {
                     V: MapAccess<'de>,
                 {
                     let mut values = Dictionary::new();
-                    while let Some((k, v)) = map.next_entry::<String, Value>()? {
+                    while let Some((k, v)) = map.next_entry()? {
                         values.insert(k, v);
                     }
                     Ok(Value::Dictionary(values))

--- a/src/value.rs
+++ b/src/value.rs
@@ -638,6 +638,12 @@ impl<'a> From<&'a str> for Value {
     }
 }
 
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Value {
+        Value::Data(value)
+    }
+}
+
 enum StackItem {
     Root(Value),
     Array(Vec<Value>),

--- a/tests/fuzzer.rs
+++ b/tests/fuzzer.rs
@@ -1,5 +1,3 @@
-extern crate plist;
-
 use plist::{Error, Value};
 use std::io::Cursor;
 


### PR DESCRIPTION
Hi, this PR has a few improvements. If you want me to remove anything, please tell me!
- Update dependencies and use serde's `derive` feature instead of the `serde_derive` crate
- Remove extern crates since I think best practice is to `use` them
- Improve dictionary `insert` function to take `impl Into<String>` and `impl Into<Value>`. This shouldn't break any previous usage, but it would allow for this:
```rs
// Old usage
let mut dictionary = Dictionary::new();
dictionary.insert("string".to_string(), "test".into());
dictionary.insert("integer".to_string(), 1.into());

// New usage (way easier!)
let mut dictionary = Dictionary::new();
dictionary.insert("string", "test");
dictionary.insert("integer", 1);
```
If there's any other functions that would benefit from `impl Into`, I think it would be good to add it to those but `insert` was the main one I saw.
- Implement `From<Vec<u8>>` for `Value`

All tests were passing when I ran them locally, but it seems that this may not be backwards compatible.