### PR TITLE
Add Data::from/to_xml_format

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -11,6 +11,8 @@ pub use self::xml_reader::XmlReader;
 
 mod xml_writer;
 pub use self::xml_writer::XmlWriter;
+#[cfg(feature = "serde")]
+pub(crate) use xml_writer::base64_encode_plist;
 
 use std::{
     borrow::Cow,

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -287,7 +287,7 @@ impl From<XmlWriterError> for Error {
     }
 }
 
-fn base64_encode_plist(data: &[u8], indent: usize) -> String {
+pub(crate) fn base64_encode_plist(data: &[u8], indent: usize) -> String {
     // XML plist data elements are always formatted by apple tools as
     // <data>
     // AAAA..AA (68 characters per line)


### PR DESCRIPTION
This mirrors the similar methods on the `Date` type.

I'm in a funny situation where I need to construct a plist that is embedded in another XML document; I'm doing this by writing custom derive impls for the various Value types, and having these methods live here saves me from needing to manage the base64 dependency myself.

No sweat if this feels overly specific, I have other options this is just the simplest for me.