### PR TITLE
Update time to 0.3.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            channel: 1.63.0
+            channel: 1.68.0
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             channel: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/plist/"
 keywords = ["plist", "parser"]
 categories = ["config", "encoding", "parser-implementations"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.68"
 
 [features]
 default = ["serde"]
@@ -17,7 +17,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.21.0"
-time = { version = "0.3.3", features = ["parsing", "formatting"] }
+time = { version = "0.3.30", features = ["parsing", "formatting"] }
 indexmap = "2.1.0"
 line-wrap = "0.1.1"
 quick_xml = { package = "quick-xml", version = "0.31.0" }


### PR DESCRIPTION
Its MSRV was raised in a patch release which was making CI builds fail.

This raises the MSRV to 1.68 instead of 1.67 in order to use sparse registries.