### PR TITLE
chore(deps): bump `line-wrap` to `0.2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 base64 = "0.21.0"
 time = { version = "0.3.30", features = ["parsing", "formatting"] }
 indexmap = "2.1.0"
-line-wrap = "0.1.1"
+line-wrap = "0.2.0"
 quick_xml = { package = "quick-xml", version = "0.31.0" }
 serde = { version = "1.0.2", optional = true }
 

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -321,7 +321,7 @@ pub(crate) fn base64_encode_plist(data: &[u8], indent: usize) -> String {
         &mut output[line_ending.len()..],
         base64_string_len,
         LINE_LEN,
-        &line_wrap::SliceLineEnding::new(&line_ending),
+        &line_wrap::SliceLineEnding::new(&line_ending).expect("not empty"),
     );
 
     // Add the final line ending and indent


### PR DESCRIPTION
Related issue: [Update line-wrap to 0.2 to avoid RUSTSEC-2023-0081 (safemem is unmaintained)](https://github.com/ebarnard/rust-plist/issues/133)