### PR TITLE
Continuation of the ASCII reader PR

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,10 @@ git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 members = ["."]
 
 [[bin]]
+name = "ascii_reader"
+path = "fuzz_targets/ascii_reader.rs"
+
+[[bin]]
 name = "binary_reader"
 path = "fuzz_targets/binary_reader.rs"
 

--- a/fuzz/fuzz_targets/ascii_reader.rs
+++ b/fuzz/fuzz_targets/ascii_reader.rs
@@ -1,0 +1,14 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate plist;
+
+use plist::stream::AsciiReader;
+use plist::Value;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    let cursor = Cursor::new(data);
+    let reader = AsciiReader::new(cursor);
+    let _ = Value::from_events(reader);
+});

--- a/src/de.rs
+++ b/src/de.rs
@@ -428,6 +428,13 @@ pub fn from_reader<R: Read + Seek, T: de::DeserializeOwned>(reader: R) -> Result
     de::Deserialize::deserialize(&mut de)
 }
 
+/// Deserializes an instance of type `T` from a byte stream containing an ASCII encoded plist.
+pub fn from_reader_ascii<R: Read, T: de::DeserializeOwned>(reader: R) -> Result<T, Error> {
+    let reader = stream::AsciiReader::new(reader);
+    let mut de = Deserializer::new(reader);
+    de::Deserialize::deserialize(&mut de)
+}
+
 /// Deserializes an instance of type `T` from a byte stream containing an XML encoded plist.
 pub fn from_reader_xml<R: Read, T: de::DeserializeOwned>(reader: R) -> Result<T, Error> {
     let reader = stream::XmlReader::new(reader);

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,6 @@ pub(crate) enum ErrorKind {
     UnclosedString,
     IncompleteComment,
     InvalidUtf8AsciiStream,
-    InvalidInteger,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ pub(crate) enum ErrorKind {
     UnclosedString,
     IncompleteComment,
     InvalidUtf8AsciiStream,
+    IoReadError,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ pub(crate) enum ErrorKind {
     UnclosedString,
     UnexpectedChar,
     IncompleteEvent,
+    IncompleteComment,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,10 @@ pub(crate) enum ErrorKind {
         found: EventKind,
     },
 
+    // Ascii format-specific errors
+    UnclosedString,
+    UnexpectedChar,
+
     // Xml format-specific errors
     UnclosedXmlElement,
     UnexpectedXmlCharactersExpectedElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ pub(crate) enum ErrorKind {
     UnclosedString,
     IncompleteComment,
     InvalidUtf8AsciiStream,
+    InvalidOctalString,
     IoReadError,
 
     // Xml format-specific errors

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,7 @@ pub(crate) enum ErrorKind {
     // Ascii format-specific errors
     UnclosedString,
     UnexpectedChar,
+    IncompleteEvent,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,7 @@ pub(crate) enum ErrorKind {
     UnexpectedChar,
     IncompleteEvent,
     IncompleteComment,
+    InvalidUtf8AsciiStream,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,6 @@ pub(crate) enum ErrorKind {
     IncompleteComment,
     InvalidUtf8AsciiStream,
     InvalidOctalString,
-    IoReadError,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,7 @@ pub(crate) enum ErrorKind {
     UnclosedString,
     IncompleteComment,
     InvalidUtf8AsciiStream,
+    InvalidInteger,
 
     // Xml format-specific errors
     UnclosedXmlElement,

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub(crate) enum ErrorKind {
 
     // Ascii format-specific errors
     UnclosedString,
-    UnexpectedChar,
-    IncompleteEvent,
     IncompleteComment,
     InvalidUtf8AsciiStream,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ mod ser;
 pub use self::{de::Deserializer, ser::Serializer};
 #[cfg(feature = "serde")]
 pub use self::{
-    de::{from_bytes, from_file, from_reader, from_reader_xml, from_value},
+    de::{from_bytes, from_file, from_reader, from_reader_ascii, from_reader_xml, from_value},
     ser::{
         to_file_binary, to_file_xml, to_value, to_writer_binary, to_writer_xml,
         to_writer_xml_with_options,

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -800,6 +800,31 @@ fn deserialize_dictionary_binary_nskeyedarchiver() {
 }
 
 #[test]
+fn xml_with_bom_and_whitespace() {
+    #[derive(Deserialize)]
+    struct LayerinfoData {
+        color: Option<String>,
+    }
+
+    let mut data = Vec::new();
+    // The UTF-8 byte order mark
+    data.extend(b"\xef\xbb\xbf");
+    data.extend(b"\r\n\t ");
+    data.extend(r#"<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>color</key>
+            <string>1,0.75,0,0.7</string>
+        </dict>
+        </plist>
+        "#.as_bytes());
+
+    let lib_dict: LayerinfoData = crate::from_bytes(&data).unwrap();
+    assert_eq!(lib_dict.color.unwrap(), "1,0.75,0,0.7");
+}
+
+#[test]
 fn dictionary_deserialize_dictionary_in_struct() {
     // Example from <https://github.com/ebarnard/rust-plist/issues/54>
     #[derive(Deserialize)]
@@ -808,7 +833,8 @@ fn dictionary_deserialize_dictionary_in_struct() {
         lib: Option<Dictionary>,
     }
 
-    let lib_dict: LayerinfoData = crate::from_bytes(r#"<?xml version="1.0" encoding="UTF-8"?>
+    let lib_dict: LayerinfoData = crate::from_bytes(r#"
+        <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
         <dict>

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -808,8 +808,7 @@ fn dictionary_deserialize_dictionary_in_struct() {
         lib: Option<Dictionary>,
     }
 
-    let lib_dict: LayerinfoData = crate::from_bytes(r#"
-        <?xml version="1.0" encoding="UTF-8"?>
+    let lib_dict: LayerinfoData = crate::from_bytes(r#"<?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
         <dict>

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -33,6 +33,10 @@ impl<R: Read> AsciiReader<R> {
         }
     }
 
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
     fn error(&self, kind: ErrorKind) -> Error {
         kind.with_byte_offset(self.current_pos)
     }
@@ -367,8 +371,7 @@ fn map_next_step_to_unicode(c: char) -> char {
 mod tests {
     use super::*;
     use crate::stream::Event::*;
-    use std::io::Cursor;
-    use std::{fs::File, path::Path};
+    use std::{fs::File, io::Cursor, path::Path};
 
     #[test]
     fn empty_test() {

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -98,13 +98,13 @@ impl<R: Read> AsciiReader<R> {
             };
         }
 
-        let string_literal = String::from_utf8(acc)
-            .map_err(|_e| self.error(ErrorKind::InvalidUtf8AsciiStream))?;
+        let string_literal =
+            String::from_utf8(acc).map_err(|_e| self.error(ErrorKind::InvalidUtf8AsciiStream))?;
 
         // Not ideal but does the trick for now
         match Integer::from_str(&string_literal) {
             Ok(i) => Ok(Some(Event::Integer(i))),
-            Err(_) => Ok(Some(Event::String(string_literal))),
+            Err(_) => Ok(Some(Event::String(string_literal.into()))),
         }
     }
 
@@ -135,7 +135,7 @@ impl<R: Read> AsciiReader<R> {
                 if c as char == '"' {
                     let string_literal = String::from_utf8(acc)
                         .map_err(|_e| self.error(ErrorKind::InvalidUtf8AsciiStream))?;
-                    Ok(Some(Event::String(string_literal)))
+                    Ok(Some(Event::String(string_literal.into())))
                 } else {
                     Err(self.error(ErrorKind::UnclosedString))
                 }
@@ -259,24 +259,24 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-            String("KeyName1".to_owned()),
-            String("Value1".to_owned()),
-            String("AnotherKeyName".to_owned()),
-            String("Value2".to_owned()),
-            String("Something".to_owned()),
+            String("KeyName1".into()),
+            String("Value1".into()),
+            String("AnotherKeyName".into()),
+            String("Value2".into()),
+            String("Something".into()),
             StartArray(None),
-            String("ArrayItem1".to_owned()),
-            String("ArrayItem2".to_owned()),
-            String("ArrayItem3".to_owned()),
+            String("ArrayItem1".into()),
+            String("ArrayItem2".into()),
+            String("ArrayItem3".into()),
             EndCollection,
-            String("Key4".to_owned()),
-            String("0.10".to_owned()),
-            String("KeyFive".to_owned()),
+            String("Key4".into()),
+            String("0.10".into()),
+            String("KeyFive".into()),
             StartDictionary(None),
-            String("Dictionary2Key1".to_owned()),
-            String("Something".to_owned()),
-            String("AnotherKey".to_owned()),
-            String("Somethingelse".to_owned()),
+            String("Dictionary2Key1".into()),
+            String("Something".into()),
+            String("AnotherKey".into()),
+            String("Somethingelse".into()),
             EndCollection,
             EndCollection,
         ];
@@ -292,34 +292,34 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-            String("AnimalColors".to_owned()),
+            String("AnimalColors".into()),
             StartDictionary(None),
-            String("lamb".to_owned()), // key
-            String("black".to_owned()),
-            String("pig".to_owned()), // key
-            String("pink".to_owned()),
-            String("worm".to_owned()), // key
-            String("pink".to_owned()),
+            String("lamb".into()), // key
+            String("black".into()),
+            String("pig".into()), // key
+            String("pink".into()),
+            String("worm".into()), // key
+            String("pink".into()),
             EndCollection,
-            String("AnimalSmells".to_owned()),
+            String("AnimalSmells".into()),
             StartDictionary(None),
-            String("lamb".to_owned()), // key
-            String("lambish".to_owned()),
-            String("pig".to_owned()), // key
-            String("piggish".to_owned()),
-            String("worm".to_owned()), // key
-            String("wormy".to_owned()),
+            String("lamb".into()), // key
+            String("lambish".into()),
+            String("pig".into()), // key
+            String("piggish".into()),
+            String("worm".into()), // key
+            String("wormy".into()),
             EndCollection,
-            String("AnimalSounds".to_owned()),
+            String("AnimalSounds".into()),
             StartDictionary(None),
-            String("Lisa".to_owned()), // key
-            String("Why is the worm talking like a lamb?".to_owned()),
-            String("lamb".to_owned()), // key
-            String("baa".to_owned()),
-            String("pig".to_owned()), // key
-            String("oink".to_owned()),
-            String("worm".to_owned()), // key
-            String("baa".to_owned()),
+            String("Lisa".into()), // key
+            String("Why is the worm talking like a lamb?".into()),
+            String("lamb".into()), // key
+            String("baa".into()),
+            String("pig".into()), // key
+            String("oink".into()),
+            String("worm".into()), // key
+            String("baa".into()),
             EndCollection,
             EndCollection,
         ];
@@ -336,12 +336,12 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-            String("names".to_owned()),
+            String("names".into()),
             StartArray(None),
-            String("Léa".to_owned()),
-            String("François".to_owned()),
-            String("Żaklina".to_owned()),
-            String("王芳".to_owned()),
+            String("Léa".into()),
+            String("François".into()),
+            String("Żaklina".into()),
+            String("王芳".into()),
             EndCollection,
             EndCollection,
         ];
@@ -358,8 +358,8 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-            String("key".to_owned()),
-            String(r#"va\"lue"#.to_owned()),
+            String("key".into()),
+            String(r#"va\"lue"#.into()),
             EndCollection,
         ];
 
@@ -375,9 +375,9 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-            String("name".to_owned()),
-            String("James".to_owned()),
-            String("age".to_owned()),
+            String("name".into()),
+            String("James".into()),
+            String("age".into()),
             Integer(42.into()),
             EndCollection,
         ];

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -1,0 +1,328 @@
+/// Documentation:
+/// - [Apple](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/OldStylePlists/OldStylePLists.html)
+/// - [GNUStep](http://wiki.gnustep.org/index.php?title=Property_Lists)
+/// - [Binary Format](https://medium.com/@karaiskc/understanding-apples-binary-property-list-format-281e6da00dbd)
+///
+
+use std::{
+    io::{Read, Seek, SeekFrom},
+    str::FromStr,
+};
+use crate::{
+    error::{Error, ErrorKind, FilePosition},
+    stream::Event,
+    Date, Integer,
+};
+
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenKind {
+    // Single-character tokens.
+    LeftParen,
+    RightParen,
+    LeftBrace,
+    RightBrace,
+    Comma,
+    SemiColon,
+    Quote,
+    Slash,
+    Star,
+
+    // One or two character tokens.
+    Equal,
+    LineComment,
+    BlockCommentLeft,  // ie., /*
+    BlockCommentRight, // ie., */
+
+    // Literals.
+    String(String),
+    Number(f32),
+
+    Eof,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub lexeme: String,
+    pub line: usize,
+}
+
+impl Token {
+    pub fn new(kind: TokenKind, lexeme: String, line: usize) -> Self {
+        Token {
+            kind,
+            lexeme,
+            line,
+        }
+    }
+}
+
+
+
+
+pub struct AsciiReader<R: Read + Seek> {
+    reader: R,
+    current_token: Vec<u8>,
+    finished: bool,
+    tokens: Vec<String>,
+    had_errors: bool,
+
+    /// start of the current lexeme
+    lexeme_start: usize,
+    current: usize,
+    line: usize,
+}
+
+impl<R: Read + Seek> AsciiReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader: reader,
+            current_token: Vec::new(),
+            finished: false,
+            tokens: Vec::new(),
+            had_errors: false,
+            start: 0,
+            current: 0,
+            line: 1,
+        }
+    }
+
+    /// Get the char without consuming it.
+    fn peek(&self) -> char {
+        let peeked = self.advance().unwrap_or('\0');
+        self.reader.seek(SeekFrom::Current(-1));
+        peeked
+    }
+
+    /// Get the next char without consuming it.
+    fn peek_next(&self) -> char {
+        self.reader.seek(SeekFrom::Current(1));
+        let peeked = self.advance().unwrap_or('\0');
+        self.reader.seek(SeekFrom::Current(-2));
+        peeked
+    }
+
+    fn advance(&mut self) -> Option<char> {
+        // self.source.chars().nth(self.current - 1)
+        // self.current = self.current + 1;
+        let mut buf: [u8; 1] = [0; 1];
+
+        match self.reader.read(&mut buf) {
+            Ok(n) => {
+                if n == 0 {
+                    None
+                } else {
+                    Some(buf[0] as char)
+                }
+            }
+            Err(_) => None
+        }
+    }
+
+    fn add_token(&mut self, kind: TokenKind) {
+        let reader_pos = self.reader.seek(SeekFrom::Current(0)).unwrap();
+        let length = self.current - self.lexeme_start;
+
+        let buf: Vec<u8> = Vec::with_capacity(length);
+        self.reader.read(buf.as_mut_slice());
+
+        // Goes back FIXME: NEEDED?
+        self.reader.seek(SeekFrom::Start(reader_pos));
+
+        // See add_token from rlox
+
+        let token = Token::new(kind, text_slice.to_owned(), self.line);
+
+        self.tokens.push(token);
+    }
+
+    fn scan_token(&mut self) {
+        let c = match self.advance() {
+            Some(c) => c,
+            None => return
+        };
+
+        match c {
+            // Single char tokens
+            '(' => self.add_token(TokenKind::LeftParen,),
+            ')' => self.add_token(TokenKind::RightParen),
+            '{' => self.add_token(TokenKind::LeftBrace),
+            '}' => self.add_token(TokenKind::RightBrace),
+            ',' => self.add_token(TokenKind::Comma),
+            ';' => self.add_token(TokenKind::SemiColon),
+            '=' => self.add_token(TokenKind::Equal),
+
+            // Single or two char(s) tokens
+            '!' => {
+                let token = if self.advance_if_matches('=') {
+                    TokenKind::BangEqual
+                } else {
+                    TokenKind::Bang
+                };
+                self.add_token(token)
+            },
+            '=' => {
+                let token = if self.advance_if_matches('=') {
+                    TokenKind::EqualEqual
+                } else {
+                    TokenKind::Equal
+                };
+                self.add_token(token)
+            },
+
+            // '/' can be a commented line.
+            '/' => {
+                if self.advance_if_matches('/') {
+                    // consume the comment without doing anything with it.
+                    while self.peek() != '\n' && !self.is_at_end() {
+                        self.advance();
+                    }
+                } else {
+                    self.add_token(TokenKind::Slash);
+                }
+            },
+
+            // Eats whitespace
+            ' ' | '\r' | '\t' => { /* Do Nothing */},
+
+            '\n' => self.line = self.line + 1,
+
+            // literals
+            '"' => self.string_literal(),
+            '0'..='9' => self.number_literal(),
+
+            // identifer & keywords
+            'a'..='z' | 'A'..='Z' | '_' => self.identifier(),
+
+            // Don't know what to do with these.
+            _ => self.error(self.line, "Unexpected character".to_owned())
+        }
+    }
+
+
+
+
+
+
+
+
+    fn is_token_complete(&self) -> bool {
+        false
+    }
+
+
+    // Possible events
+    //     StartArray(Option<u64>),
+    //     StartDictionary(Option<u64>),
+    //     EndCollection,
+
+    //     Boolean(bool),
+    //     Data(Vec<u8>),
+    //     Date(Date),
+    //     Integer(Integer),
+    //     Real(f64),
+    //     String(String),
+    //     Uid(Uid),
+    fn event_for_current_token(&self) -> Result<Option<Event>, Error> {
+
+    }
+
+    // fn advance(&mut self) {
+    //     let mut buf = [0; 1];
+    //     match self.reader.read(buf) {
+    //         Ok(n) => {
+    //             if n == 0 {
+    //                 self.finished = true;
+    //             } else {
+    //                 self.current_token.append(buf[0]);
+    //             }
+    //         },
+    //         Err(_e) =>  { /* FIXME: handle this case */ }
+    //     }
+    // }
+
+    fn read_next(&mut self) -> Result<Option<Event>, Error> {
+        if self.finished {
+            return Ok(None)
+        } else {
+            while !self.is_token_complete() {
+                self.advance();
+            }
+
+            self.event_for_current_token()
+        }
+    }
+}
+
+impl<R: Read + Seek> Iterator for AsciiReader<R> {
+    type Item = Result<Event, Error>;
+
+    fn next(&mut self) -> Option<Result<Event, Error>> {
+        match self.read_next() {
+            Ok(Some(event)) => Some(Ok(event)),
+            Err(err) => {
+                // Mark the plist as finished
+                // self.stack.clear();
+                Some(Err(err))
+            }
+            Ok(None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, path::Path};
+
+    use super::*;
+    use crate::stream::Event::{self, *};
+
+    #[test]
+    fn streaming_animals() {
+        let reader = File::open(&Path::new("./tests/data/ascii-animals.plist")).unwrap();
+        let streaming_parser = AsciiReader::new(reader);
+        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
+
+        let comparison = &[
+            StartDictionary(None),
+
+            String("AnimalColors".to_owned()),
+            StartDictionary(None),
+            String("lamb".to_owned()), // key
+            String("black".to_owned()),
+            String("pig".to_owned()), // key
+            String("pink".to_owned()),
+            String("worm".to_owned()), // key
+            String("pink".to_owned()),
+            EndCollection,
+
+
+            String("AnimalSmells".to_owned()),
+            StartDictionary(None),
+            String("lamb".to_owned()), // key
+            String("lambish".to_owned()),
+            String("pig".to_owned()), // key
+            String("piggish".to_owned()),
+            String("worm".to_owned()), // key
+            String("wormy".to_owned()),
+            EndCollection,
+
+            String("AnimalSounds".to_owned()),
+            StartDictionary(None),
+            String("Lisa".to_owned()), // key
+            String("Why is the worm talking like a lamb?".to_owned()),
+            String("lamb".to_owned()), // key
+            String("baa".to_owned()),
+            String("pig".to_owned()), // key
+            String("oink".to_owned()),
+            String("worm".to_owned()), // key
+            String("baa".to_owned()),
+            EndCollection,
+
+            EndCollection,
+        ];
+
+        assert_eq!(events, comparison);
+    }
+}

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -268,7 +268,9 @@ impl<R: Read> AsciiReader<R> {
                     None => false,
                 }
         } {
-            latest_consume = self.advance()?.unwrap_or(b' ');
+            latest_consume = self
+                .advance()?
+                .ok_or(self.error(ErrorKind::IncompleteComment))?;
         }
 
         Ok(())

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -19,6 +19,8 @@ pub struct AsciiReader<R: Read> {
 
     /// lookahead char to avoid backtracking.
     peeked_char: Option<u8>,
+
+    current_char: Option<u8>,
 }
 
 impl<R: Read> AsciiReader<R> {
@@ -27,6 +29,7 @@ impl<R: Read> AsciiReader<R> {
             reader,
             current_pos: 0,
             peeked_char: None,
+            current_char: None,
         }
     }
 
@@ -48,23 +51,24 @@ impl<R: Read> AsciiReader<R> {
         }
     }
 
-    /// Consume the reader and return the next char.
+    /// Consume the reader and set [`Self::current_char`] and
+    /// [`Self::peeked_char`]. Returns the current character.
     fn advance(&mut self) -> Result<Option<u8>, Error> {
-        let mut cur_char = self.peeked_char;
+        self.current_char = self.peeked_char;
         self.peeked_char = self.read_one()?;
 
         // We need to read two chars to boot the process and fill the peeked
         // char.
         if self.current_pos == 0 {
-            cur_char = self.peeked_char;
+            self.current_char = self.peeked_char;
             self.peeked_char = self.read_one()?;
         }
 
-        if cur_char.is_some() {
+        if self.current_char.is_some() {
             self.current_pos += 1;
         }
 
-        Ok(cur_char)
+        Ok(self.current_char)
     }
 
     /// From Apple doc:
@@ -91,7 +95,8 @@ impl<R: Read> AsciiReader<R> {
             }
         } {
             // consuming the string itself
-            match self.advance()? {
+            self.advance()?;
+            match self.current_char {
                 Some(c) => acc.push(c),
                 None => return Err(self.error(ErrorKind::UnclosedString)),
             };
@@ -107,39 +112,134 @@ impl<R: Read> AsciiReader<R> {
         }
     }
 
-    fn quoted_string_literal(&mut self) -> Result<Option<OwnedEvent>, Error> {
-        let mut acc: Vec<u8> = Vec::new();
-        let mut cur_char = b'"';
+    /// The process for decoding utf-16 escapes to utf-8 is:
+    /// 1. Convert the 4 hex characters to utf-16 code units (u16s).
+    ///    '\u006d' becomes 0x6d.
+    /// 2. Based on the first code unit, determine whether another code unit is
+    ///    required to form the complete code point.
+    ///    "\uD83D\uDCA9" becomes `[0xd73d, 0xdca9]`
+    /// 3. Convert the 1 or 2 u16 code point to utf-8.
+    ///    `[0xd73d, 0xdca9]` becomes '💩'.
+    ///
+    /// The standard library has some useful functions behind unstable feature
+    /// flags, we can simplify and optimize this a bit once they're stable.
+    /// - str_from_utf16_endian
+    /// - is_utf16_surrogate
+    fn utf16_escape(&mut self) -> Result<String, Error> {
+        let mut code_units: &mut [u16] = &mut [0u16; 2];
 
-        while {
-            match self.peeked_char {
-                // do not stop if the quote is escaped
-                Some(c) => c != b'"' || cur_char == b'\\',
-                None => false,
+        let Some(code_unit) = self.utf16_code_unit()? else {
+            return Err(self.error(ErrorKind::InvalidUtf16String));
+        };
+
+        code_units[0] = code_unit;
+
+        // This is the utf-16 surrogate range, indicating another code unit is
+        // necessary to form a complete code point.
+        if !matches!(code_unit, 0xD800..=0xDFFF) {
+            code_units = &mut code_units[0..1];
+        } else {
+            self.advance_quoted_string()?;
+
+            if self.current_char != Some(b'\\')
+                || !matches!(self.peeked_char, Some(b'u') | Some(b'U'))
+            {
+                return Err(self.error(ErrorKind::InvalidUtf16String));
             }
-        } {
-            // consuming the string itself
-            match self.advance()? {
-                Some(c) => {
-                    cur_char = c;
-                    acc.push(c)
-                }
-                None => return Err(self.error(ErrorKind::UnclosedString)),
-            };
+
+            self.advance_quoted_string()?;
+
+            if let Some(code_unit) = self.utf16_code_unit()? {
+                code_units[1] = code_unit;
+            }
         }
 
-        // Match the closing quote.
+        let utf8 = String::from_utf16(code_units)
+            .map_err(|_| self.error(ErrorKind::InvalidUtf16String))?;
+
+        Ok(utf8)
+    }
+
+    /// Expects the reader's next read to return the first hex character of the
+    /// utf-16 hex string.
+    fn utf16_code_unit(&mut self) -> Result<Option<u16>, Error> {
+        let hex_chars = [
+            self.advance_quoted_string()?,
+            self.advance_quoted_string()?,
+            self.advance_quoted_string()?,
+            self.advance_quoted_string()?,
+        ];
+
+        let hex_str = std::str::from_utf8(&hex_chars)
+            .map_err(|_| self.error(ErrorKind::InvalidUtf16String))?;
+
+        let code_unit = u16::from_str_radix(hex_str, 16)
+            .map_err(|_| self.error(ErrorKind::InvalidUtf16String))?;
+
+        Ok(Some(code_unit))
+    }
+
+    #[inline]
+    fn advance_quoted_string(&mut self) -> Result<u8, Error> {
         match self.advance()? {
-            Some(c) => {
-                if c as char == '"' {
-                    let string_literal = String::from_utf8(acc)
-                        .map_err(|_e| self.error(ErrorKind::InvalidUtf8AsciiStream))?;
-                    Ok(Some(Event::String(string_literal.into())))
-                } else {
-                    Err(self.error(ErrorKind::UnclosedString))
-                }
-            }
+            Some(c) => Ok(c),
             None => Err(self.error(ErrorKind::UnclosedString)),
+        }
+    }
+
+    fn quoted_string_literal(&mut self, quote: u8) -> Result<Option<OwnedEvent>, Error> {
+        let mut acc = String::new();
+
+        loop {
+            let c = self.advance_quoted_string()?;
+
+            if c == quote {
+                return Ok(Some(Event::String(acc.into())));
+            }
+
+            let replacement = if c == b'\\' {
+                let c = self.advance_quoted_string()?;
+
+                match c {
+                    b'\\' | b'"' => c as char,
+                    b'a' => '\u{7}',
+                    b'b' => '\u{8}',
+                    b'f' => '\u{c}',
+                    b'n' => '\n',
+                    b'r' => '\r',
+                    b't' => '\t',
+                    b'U' => {
+                        let utf8 = self.utf16_escape()?;
+                        acc.push_str(utf8.as_str());
+                        continue;
+                    }
+                    b'v' => '\u{b}',
+                    b'0' | b'1' | b'2' | b'3' | b'4' | b'5' | b'6' | b'7' => {
+                        let value = [
+                            c,
+                            self.advance_quoted_string()?,
+                            self.advance_quoted_string()?,
+                        ];
+
+                        let value = std::str::from_utf8(&value)
+                            .map_err(|_| self.error(ErrorKind::InvalidOctalString))?;
+
+                        let value = u16::from_str_radix(value, 8)
+                            .map_err(|_| self.error(ErrorKind::InvalidOctalString))?
+                            as u32;
+
+                        let value = char::from_u32(value)
+                            .ok_or(self.error(ErrorKind::InvalidOctalString))?;
+
+                        map_next_step_to_unicode(value)
+                    }
+                    _ => return Err(self.error(ErrorKind::InvalidUtf8AsciiStream)),
+                }
+            } else {
+                c as char
+            };
+
+            acc.push(replacement);
         }
     }
 
@@ -203,7 +303,7 @@ impl<R: Read> AsciiReader<R> {
                 b')' => return Ok(Some(Event::EndCollection)),
                 b'{' => return Ok(Some(Event::StartDictionary(None))),
                 b'}' => return Ok(Some(Event::EndCollection)),
-                b'"' => return self.quoted_string_literal(),
+                b'\'' | b'"' => return self.quoted_string_literal(c),
                 b'/' => {
                     match self.potential_comment() {
                         Ok(Some(event)) => return Ok(Some(event)),
@@ -231,6 +331,38 @@ impl<R: Read> Iterator for AsciiReader<R> {
             Err(err) => Some(Err(err)),
         }
     }
+}
+
+/// Maps NextStep encoding to Unicode, see:
+/// - https://github.com/fonttools/openstep-plist/blob/master/src/openstep_plist/parser.pyx#L87-L106
+/// - ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/NEXT/NEXTSTEP.TXT
+fn map_next_step_to_unicode(c: char) -> char {
+    const NEXT_UNICODE_MAPPING: &[char] = &[
+        '\u{A0}', '\u{C0}', '\u{C1}', '\u{C2}', '\u{C3}', '\u{C4}', '\u{C5}', '\u{C7}', '\u{C8}',
+        '\u{C9}', '\u{CA}', '\u{CB}', '\u{CC}', '\u{CD}', '\u{CE}', '\u{CF}', '\u{D0}', '\u{D1}',
+        '\u{D2}', '\u{D3}', '\u{D4}', '\u{D5}', '\u{D6}', '\u{D9}', '\u{DA}', '\u{DB}', '\u{DC}',
+        '\u{DD}', '\u{DE}', '\u{B5}', '\u{D7}', '\u{F7}', '\u{A9}', '\u{A1}', '\u{A2}', '\u{A3}',
+        '\u{2044}', '\u{A5}', '\u{192}', '\u{A7}', '\u{A4}', '\u{2019}', '\u{201C}', '\u{AB}',
+        '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}', '\u{AE}', '\u{2013}', '\u{2020}',
+        '\u{2021}', '\u{B7}', '\u{A6}', '\u{B6}', '\u{2022}', '\u{201A}', '\u{201E}', '\u{201D}',
+        '\u{BB}', '\u{2026}', '\u{2030}', '\u{AC}', '\u{BF}', '\u{B9}', '\u{2CB}', '\u{B4}',
+        '\u{2C6}', '\u{2DC}', '\u{AF}', '\u{2D8}', '\u{2D9}', '\u{A8}', '\u{B2}', '\u{2DA}',
+        '\u{B8}', '\u{B3}', '\u{2DD}', '\u{2DB}', '\u{2C7}', '\u{2014}', '\u{B1}', '\u{BC}',
+        '\u{BD}', '\u{BE}', '\u{E0}', '\u{E1}', '\u{E2}', '\u{E3}', '\u{E4}', '\u{E5}', '\u{E7}',
+        '\u{E8}', '\u{E9}', '\u{EA}', '\u{EB}', '\u{EC}', '\u{C6}', '\u{ED}', '\u{AA}', '\u{EE}',
+        '\u{EF}', '\u{F0}', '\u{F1}', '\u{141}', '\u{D8}', '\u{152}', '\u{BA}', '\u{F2}', '\u{F3}',
+        '\u{F4}', '\u{F5}', '\u{F6}', '\u{E6}', '\u{F9}', '\u{FA}', '\u{FB}', '\u{131}', '\u{FC}',
+        '\u{FD}', '\u{142}', '\u{F8}', '\u{153}', '\u{DF}', '\u{FE}', '\u{FF}', '\u{FFFD}',
+        '\u{FFFD}',
+    ];
+
+    let index = c as usize;
+
+    if index < 128 || index > 0xff {
+        return c;
+    }
+
+    NEXT_UNICODE_MAPPING[index - 128]
 }
 
 #[cfg(test)]
@@ -348,16 +480,74 @@ mod tests {
     }
 
     #[test]
-    fn escaped_quotes_in_strings() {
-        let plist = r#"{ key = "va\"lue" }"#;
-        let cursor = Cursor::new(plist.as_bytes());
+    fn invalid_utf16_escapes() {
+        let plist = br#"{
+            key1 = "\U123";
+            key2 = "\UD83D";
+            key3 = "\u0080";
+        }"#;
+        let cursor = Cursor::new(plist);
+        let streaming_parser = AsciiReader::new(cursor);
+        let events: Vec<Result<Event, Error>> = streaming_parser.collect();
+
+        // key1's value
+        assert!(events[2].is_err());
+        // key2's value
+        assert!(events[4].is_err());
+        // key3's value
+        assert!(events[6].is_err());
+    }
+
+    #[test]
+    fn invalid_octal_escapes() {
+        let plist = br#"{
+            key1 = "\1";
+            key2 = "\12";
+        }"#;
+        let cursor = Cursor::new(plist);
+        let streaming_parser = AsciiReader::new(cursor);
+        let events: Vec<Result<Event, Error>> = streaming_parser.collect();
+
+        // key1's value
+        assert!(events[2].is_err());
+        // key2's value
+        assert!(events[4].is_err());
+    }
+
+    #[test]
+    fn escaped_sequences_in_strings() {
+        let plist = br#"{
+            key1 = "va\"lue";
+            key2 = 'va"lue';
+            key3 = "va\a\b\f\n\r\t\v\"\nlue";
+            key4 = "a\012b";
+            key5 = "\\UD83D\\UDCA9";
+            key6 = "\UD83D\UDCA9";
+            key7 = "\U0080";
+            key8 = "\200\377";
+        }"#;
+        let cursor = Cursor::new(plist);
         let streaming_parser = AsciiReader::new(cursor);
         let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
 
         let comparison = &[
             StartDictionary(None),
-            String("key".into()),
-            String(r#"va\"lue"#.into()),
+            String("key1".into()),
+            String(r#"va"lue"#.into()),
+            String("key2".into()),
+            String(r#"va"lue"#.into()),
+            String("key3".into()),
+            String("va\u{7}\u{8}\u{c}\n\r\t\u{b}\"\nlue".into()),
+            String("key4".into()),
+            String("a\nb".into()),
+            String("key5".into()),
+            String("\\UD83D\\UDCA9".into()),
+            String("key6".into()),
+            String("💩".into()),
+            String("key7".into()),
+            String("\u{80}".into()),
+            String("key8".into()),
+            String("\u{a0}\u{fffd}".into()),
             EndCollection,
         ];
 

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -369,9 +369,10 @@ fn map_next_step_to_unicode(c: char) -> char {
 
 #[cfg(test)]
 mod tests {
+    use std::{fs::File, io::Cursor};
+
     use super::*;
     use crate::stream::Event::*;
-    use std::{fs::File, io::Cursor, path::Path};
 
     #[test]
     fn empty_test() {
@@ -384,7 +385,7 @@ mod tests {
 
     #[test]
     fn streaming_sample() {
-        let reader = File::open(&Path::new("./tests/data/ascii-sample.plist")).unwrap();
+        let reader = File::open("./tests/data/ascii-sample.plist").unwrap();
         let streaming_parser = AsciiReader::new(reader);
         let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
 
@@ -408,49 +409,6 @@ mod tests {
             String("Something".into()),
             String("AnotherKey".into()),
             String("Somethingelse".into()),
-            EndCollection,
-            EndCollection,
-        ];
-
-        assert_eq!(events, comparison);
-    }
-
-    #[test]
-    fn streaming_animals() {
-        let reader = File::open(&Path::new("./tests/data/ascii-animals.plist")).unwrap();
-        let streaming_parser = AsciiReader::new(reader);
-        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
-
-        let comparison = &[
-            StartDictionary(None),
-            String("AnimalColors".into()),
-            StartDictionary(None),
-            String("lamb".into()), // key
-            String("black".into()),
-            String("pig".into()), // key
-            String("pink".into()),
-            String("worm".into()), // key
-            String("pink".into()),
-            EndCollection,
-            String("AnimalSmells".into()),
-            StartDictionary(None),
-            String("lamb".into()), // key
-            String("lambish".into()),
-            String("pig".into()), // key
-            String("piggish".into()),
-            String("worm".into()), // key
-            String("wormy".into()),
-            EndCollection,
-            String("AnimalSounds".into()),
-            StartDictionary(None),
-            String("Lisa".into()), // key
-            String("Why is the worm talking like a lamb?".into()),
-            String("lamb".into()), // key
-            String("baa".into()),
-            String("pig".into()), // key
-            String("oink".into()),
-            String("worm".into()), // key
-            String("baa".into()),
             EndCollection,
             EndCollection,
         ];
@@ -576,7 +534,7 @@ mod tests {
 
     #[test]
     fn netnewswire_pbxproj() {
-        let reader = File::open(&Path::new("./tests/data/netnewswire.pbxproj")).unwrap();
+        let reader = File::open("./tests/data/netnewswire.pbxproj").unwrap();
         let streaming_parser = AsciiReader::new(reader);
 
         // Ensure that we don't fail when reading the file

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -98,13 +98,13 @@ impl<R: Read> AsciiReader<R> {
             };
         }
 
-        let string_literal = std::str::from_utf8(&acc)
+        let string_literal = String::from_utf8(acc)
             .map_err(|_e| self.error(ErrorKind::InvalidUtf8AsciiStream))?;
 
         // Not ideal but does the trick for now
-        match Integer::from_str(string_literal) {
+        match Integer::from_str(&string_literal) {
             Ok(i) => Ok(Some(Event::Integer(i))),
-            Err(_) => Ok(Some(Event::String(string_literal.to_owned()))),
+            Err(_) => Ok(Some(Event::String(string_literal))),
         }
     }
 

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -45,7 +45,7 @@ impl<R: Read> AsciiReader<R> {
                 if err.kind() == std::io::ErrorKind::UnexpectedEof {
                     Ok(None)
                 } else {
-                    Err(self.error(ErrorKind::IoReadError))
+                    Err(self.error(ErrorKind::Io(err)))
                 }
             }
         }
@@ -325,11 +325,7 @@ impl<R: Read> Iterator for AsciiReader<R> {
     type Item = Result<OwnedEvent, Error>;
 
     fn next(&mut self) -> Option<Result<OwnedEvent, Error>> {
-        match self.read_next() {
-            Ok(Some(event)) => Some(Ok(event)),
-            Ok(None) => None,
-            Err(err) => Some(Err(err)),
-        }
+        self.read_next().transpose()
     }
 }
 

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -1,8 +1,8 @@
 /// Ascii property lists are used in legacy settings and only support four
 /// datatypes: Array, Dictionary, String and Data.
 /// See [Apple
-/// Documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/OldStylePlists/OldStylePLists.htf
-/// for more infos.
+/// Documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/PropertyLists/OldStylePlists/OldStylePLists.html)
+/// for more info.
 /// However this reader also support Integers as first class datatype.
 /// This reader will accept certain ill-formed ascii plist without complaining.
 /// It does not check the integrity of the plist format.
@@ -293,10 +293,10 @@ impl<R: Read> AsciiReader<R> {
 
     /// Consumes the reader until it finds a valid Event
     /// Possible events for Ascii plists:
-    ///  - StartArray(Option<u64>),
-    ///  - StartDictionary(Option<u64>),
-    ///  - EndCollection,
-    ///  - Data(Vec<u8>),
+    ///  - `StartArray(Option<u64>)`,
+    ///  - `StartDictionary(Option<u64>)`,
+    ///  - `EndCollection`,
+    ///  - `Data(Vec<u8>)`,
     fn read_next(&mut self) -> Result<Option<OwnedEvent>, Error> {
         while let Some(c) = self.advance()? {
             match c {
@@ -332,8 +332,8 @@ impl<R: Read> Iterator for AsciiReader<R> {
 }
 
 /// Maps NextStep encoding to Unicode, see:
-/// - https://github.com/fonttools/openstep-plist/blob/master/src/openstep_plist/parser.pyx#L87-L106
-/// - ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/NEXT/NEXTSTEP.TXT
+/// - <https://github.com/fonttools/openstep-plist/blob/master/src/openstep_plist/parser.pyx#L87-L106>
+/// - <ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/NEXT/NEXTSTEP.TXT>
 fn map_next_step_to_unicode(c: char) -> char {
     const NEXT_UNICODE_MAPPING: &[char] = &[
         '\u{A0}', '\u{C0}', '\u{C1}', '\u{C2}', '\u{C3}', '\u{C4}', '\u{C5}', '\u{C7}', '\u{C8}',
@@ -366,7 +366,7 @@ fn map_next_step_to_unicode(c: char) -> char {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stream::Event::{self, *};
+    use crate::stream::Event::*;
     use std::io::Cursor;
     use std::{fs::File, path::Path};
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -14,6 +14,9 @@ pub use self::xml_writer::XmlWriter;
 #[cfg(feature = "serde")]
 pub(crate) use xml_writer::encode_data_base64 as xml_encode_data_base64;
 
+mod ascii_reader;
+pub use self::ascii_reader::AsciiReader;
+
 use std::{
     borrow::Cow,
     io::{self, Read, Seek, SeekFrom},

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -239,7 +239,7 @@ impl<R: Read> ReaderState<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, path::Path};
+    use std::fs::File;
 
     use super::*;
     use crate::stream::Event::*;
@@ -248,7 +248,7 @@ mod tests {
     fn streaming_parser() {
         let reader = File::open("./tests/data/xml.plist").unwrap();
         let streaming_parser = XmlReader::new(reader);
-        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
+        let events: Result<Vec<_>, _> = streaming_parser.collect();
 
         let comparison = &[
             StartDictionary(None),
@@ -282,50 +282,7 @@ mod tests {
             EndCollection,
         ];
 
-        assert_eq!(events, comparison);
-    }
-
-    #[test]
-    fn streaming_animals() {
-        let reader = File::open(&Path::new("./tests/data/xml-animals.plist")).unwrap();
-        let streaming_parser = XmlReader::new(reader);
-        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
-
-        let comparison = &[
-            StartDictionary(None),
-            String("AnimalColors".into()),
-            StartDictionary(None),
-            String("lamb".into()), // key
-            String("black".into()),
-            String("pig".into()), // key
-            String("pink".into()),
-            String("worm".into()), // key
-            String("pink".into()),
-            EndCollection,
-            String("AnimalSmells".into()),
-            StartDictionary(None),
-            String("lamb".into()), // key
-            String("lambish".into()),
-            String("pig".into()), // key
-            String("piggish".into()),
-            String("worm".into()), // key
-            String("wormy".into()),
-            EndCollection,
-            String("AnimalSounds".into()),
-            StartDictionary(None),
-            String("Lisa".into()), // key
-            String("Why is the worm talking like a lamb?".into()),
-            String("lamb".into()), // key
-            String("baa".into()),
-            String("pig".into()), // key
-            String("oink".into()),
-            String("worm".into()), // key
-            String("baa".into()),
-            EndCollection,
-            EndCollection,
-        ];
-
-        assert_eq!(events, comparison);
+        assert_eq!(events.unwrap(), comparison);
     }
 
     #[test]

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -210,7 +210,7 @@ impl<R: Read> ReaderState<R> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
+    use std::{fs::File, path::Path};
 
     use super::*;
     use crate::stream::Event::*;

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -257,6 +257,54 @@ mod tests {
     }
 
     #[test]
+    fn streaming_animals() {
+        let reader = File::open(&Path::new("./tests/data/xml-animals.plist")).unwrap();
+        let streaming_parser = XmlReader::new(reader);
+        let events: Vec<Event> = streaming_parser.map(|e| e.unwrap()).collect();
+
+        let comparison = &[
+            StartDictionary(None),
+
+            String("AnimalColors".to_owned()),
+            StartDictionary(None),
+            String("lamb".to_owned()), // key
+            String("black".to_owned()),
+            String("pig".to_owned()), // key
+            String("pink".to_owned()),
+            String("worm".to_owned()), // key
+            String("pink".to_owned()),
+            EndCollection,
+
+
+            String("AnimalSmells".to_owned()),
+            StartDictionary(None),
+            String("lamb".to_owned()), // key
+            String("lambish".to_owned()),
+            String("pig".to_owned()), // key
+            String("piggish".to_owned()),
+            String("worm".to_owned()), // key
+            String("wormy".to_owned()),
+            EndCollection,
+
+            String("AnimalSounds".to_owned()),
+            StartDictionary(None),
+            String("Lisa".to_owned()), // key
+            String("Why is the worm talking like a lamb?".to_owned()),
+            String("lamb".to_owned()), // key
+            String("baa".to_owned()),
+            String("pig".to_owned()), // key
+            String("oink".to_owned()),
+            String("worm".to_owned()), // key
+            String("baa".to_owned()),
+            EndCollection,
+
+            EndCollection,
+        ];
+
+        assert_eq!(events, comparison);
+    }
+
+    #[test]
     fn bad_data() {
         let reader = File::open("./tests/data/xml_error.plist").unwrap();
         let streaming_parser = XmlReader::new(reader);

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -264,40 +264,35 @@ mod tests {
 
         let comparison = &[
             StartDictionary(None),
-
-            String("AnimalColors".to_owned()),
+            String("AnimalColors".into()),
             StartDictionary(None),
-            String("lamb".to_owned()), // key
-            String("black".to_owned()),
-            String("pig".to_owned()), // key
-            String("pink".to_owned()),
-            String("worm".to_owned()), // key
-            String("pink".to_owned()),
+            String("lamb".into()), // key
+            String("black".into()),
+            String("pig".into()), // key
+            String("pink".into()),
+            String("worm".into()), // key
+            String("pink".into()),
             EndCollection,
-
-
-            String("AnimalSmells".to_owned()),
+            String("AnimalSmells".into()),
             StartDictionary(None),
-            String("lamb".to_owned()), // key
-            String("lambish".to_owned()),
-            String("pig".to_owned()), // key
-            String("piggish".to_owned()),
-            String("worm".to_owned()), // key
-            String("wormy".to_owned()),
+            String("lamb".into()), // key
+            String("lambish".into()),
+            String("pig".into()), // key
+            String("piggish".into()),
+            String("worm".into()), // key
+            String("wormy".into()),
             EndCollection,
-
-            String("AnimalSounds".to_owned()),
+            String("AnimalSounds".into()),
             StartDictionary(None),
-            String("Lisa".to_owned()), // key
-            String("Why is the worm talking like a lamb?".to_owned()),
-            String("lamb".to_owned()), // key
-            String("baa".to_owned()),
-            String("pig".to_owned()), // key
-            String("oink".to_owned()),
-            String("worm".to_owned()), // key
-            String("baa".to_owned()),
+            String("Lisa".into()), // key
+            String("Why is the worm talking like a lamb?".into()),
+            String("lamb".into()), // key
+            String("baa".into()),
+            String("pig".into()), // key
+            String("oink".into()),
+            String("worm".into()), // key
+            String("baa".into()),
             EndCollection,
-
             EndCollection,
         ];
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,7 +8,8 @@ use std::{
 use crate::{
     error::{self, Error, ErrorKind, EventKind},
     stream::{
-        private, BinaryWriter, Event, Events, Reader, Writer, XmlReader, XmlWriteOptions, XmlWriter,
+        private, AsciiReader, BinaryWriter, Event, Events, Reader, Writer, XmlReader,
+        XmlWriteOptions, XmlWriter,
     },
     u64_to_usize, Date, Dictionary, Integer, Uid,
 };
@@ -41,7 +42,13 @@ impl Value {
         Value::from_events(reader)
     }
 
-    /// Reads a `Value` from a seekable byte stream containing an XML encoded plist.
+    /// Reads a `Value` from a byte stream containing an ASCII encoded plist.
+    pub fn from_reader_ascii<R: Read>(reader: R) -> Result<Value, Error> {
+        let reader = AsciiReader::new(reader);
+        Value::from_events(reader)
+    }
+
+    /// Reads a `Value` from a byte stream containing an XML encoded plist.
     pub fn from_reader_xml<R: Read>(reader: R) -> Result<Value, Error> {
         let reader = XmlReader::new(reader);
         Value::from_events(reader)

--- a/tests/data/ascii-animals.plist
+++ b/tests/data/ascii-animals.plist
@@ -1,6 +1,6 @@
 {
-    AnimalSmells = { pig = piggish; lamb = lambish; worm = wormy; };
-    AnimalSounds = { pig = oink; lamb = baa; worm = baa;
-                    Lisa = "Why is the worm talking like a lamb?"; };
-    AnimalColors = { pig = pink; lamb = black; worm = pink; };
+    AnimalColors = { lamb = black; pig = pink; worm = pink; };
+    AnimalSmells = { lamb = lambish; pig = piggish; worm = wormy; };
+    AnimalSounds = { Lisa = "Why is the worm talking like a lamb?";
+                    lamb = baa; pig = oink; worm = baa; };
 }

--- a/tests/data/ascii-animals.plist
+++ b/tests/data/ascii-animals.plist
@@ -1,0 +1,6 @@
+{
+    AnimalSmells = { pig = piggish; lamb = lambish; worm = wormy; };
+    AnimalSounds = { pig = oink; lamb = baa; worm = baa;
+                    Lisa = "Why is the worm talking like a lamb?"; };
+    AnimalColors = { pig = pink; lamb = black; worm = pink; };
+}

--- a/tests/data/ascii-sample.plist
+++ b/tests/data/ascii-sample.plist
@@ -1,0 +1,9 @@
+/* Sample from GNUStep: http://wiki.gnustep.org/index.php?title=Property_Lists */
+{
+   KeyName1 = /* embedded comment */ Value1;
+   AnotherKeyName = "Value2";
+   // This should be ignored. Ignored = "Not in here"
+   Something = ( "ArrayItem1", "ArrayItem2", "ArrayItem3" );
+   Key4 = 0.10;  // Line Comment
+   KeyFive = { Dictionary2Key1 = "Something"; AnotherKey = "Somethingelse"; };
+}

--- a/tests/data/netnewswire.pbxproj
+++ b/tests/data/netnewswire.pbxproj
@@ -1,0 +1,4730 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		49F40DF82335B71000552BF4 /* newsfoot.js in Resources */ = {isa = PBXBuildFile; fileRef = 49F40DEF2335B71000552BF4 /* newsfoot.js */; };
+		49F40DF92335B71000552BF4 /* newsfoot.js in Resources */ = {isa = PBXBuildFile; fileRef = 49F40DEF2335B71000552BF4 /* newsfoot.js */; };
+		51102165233A7D6C0007A5F7 /* ArticleExtractorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51102164233A7D6C0007A5F7 /* ArticleExtractorButton.swift */; };
+		51126DA4225FDE2F00722696 /* RSImage-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51126DA3225FDE2F00722696 /* RSImage-Extensions.swift */; };
+		5115CAF42266301400B21BCE /* AddContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51121B5A22661FEF00BC0EC1 /* AddContainerViewController.swift */; };
+		511D43CF231FA62200FB1562 /* DetailKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5127B237222B4849006D641D /* DetailKeyboardShortcuts.plist */; };
+		511D43D0231FA62500FB1562 /* TimelineKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 845479871FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist */; };
+		511D43D1231FA62800FB1562 /* SidebarKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B681FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist */; };
+		511D43D2231FA62C00FB1562 /* GlobalKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B641FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist */; };
+		511D43EF231FBDE900FB1562 /* LaunchScreenPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 511D43ED231FBDE800FB1562 /* LaunchScreenPad.storyboard */; };
+		511D4419231FC02D00FB1562 /* KeyboardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511D4410231FC02D00FB1562 /* KeyboardManager.swift */; };
+		51236339236915B100951F16 /* RoundedProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512363372369155100951F16 /* RoundedProgressView.swift */; };
+		5123DB9F233EC6FD00282CC9 /* FeedInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5123DB9E233EC6FD00282CC9 /* FeedInspectorView.swift */; };
+		5126EE97226CB48A00C22AFC /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126EE96226CB48A00C22AFC /* SceneCoordinator.swift */; };
+		5127B238222B4849006D641D /* DetailKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5127B236222B4849006D641D /* DetailKeyboardDelegate.swift */; };
+		5127B23A222B4849006D641D /* DetailKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5127B237222B4849006D641D /* DetailKeyboardShortcuts.plist */; };
+		512E08E62268800D00BDCFDD /* FolderTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */; };
+		512E08E72268801200BDCFDD /* FeedTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97611ED9EB96007D329B /* FeedTreeControllerDelegate.swift */; };
+		512E09012268907400BDCFDD /* MasterFeedTableViewSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512E08F722688F7C00BDCFDD /* MasterFeedTableViewSectionHeader.swift */; };
+		512E09352268B25900BDCFDD /* UISplitViewController-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512E092B2268B25500BDCFDD /* UISplitViewController-Extensions.swift */; };
+		512E094D2268B8AB00BDCFDD /* DeleteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B99C9C1FAE83C600ECDEDB /* DeleteCommand.swift */; };
+		5131463E235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 51314637235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		51314668235A7E4600387FDC /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51314666235A7E4600387FDC /* IntentHandler.swift */; };
+		513146B2235A81A400387FDC /* AddFeedIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513146B1235A81A400387FDC /* AddFeedIntentHandler.swift */; };
+		513146B3235A81A400387FDC /* AddFeedIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513146B1235A81A400387FDC /* AddFeedIntentHandler.swift */; };
+		513146B4235A8FD000387FDC /* RSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8520DD8CF200CA8CF5 /* RSCore.framework */; };
+		513146B6235A8FD000387FDC /* RSDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */; };
+		513146B8235A8FD000387FDC /* RSParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; };
+		513146BA235A8FD000387FDC /* RSTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; };
+		513146BC235A8FD000387FDC /* RSWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */; };
+		513146BF235A8FDB00387FDC /* Account.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; };
+		513146C1235A8FDB00387FDC /* Articles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; };
+		513146C3235A8FDB00387FDC /* ArticlesDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; };
+		513146C5235A8FDB00387FDC /* SyncDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; };
+		51314704235C41FC00387FDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 51314707235C41FC00387FDC /* Intents.intentdefinition */; };
+		51314705235C41FC00387FDC /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 51314707235C41FC00387FDC /* Intents.intentdefinition */; };
+		513228FB233037630033D4ED /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513228F2233037620033D4ED /* Reachability.swift */; };
+		513228FC233037630033D4ED /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513228F2233037620033D4ED /* Reachability.swift */; };
+		513C5CE9232571C2003D4054 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513C5CE8232571C2003D4054 /* ShareViewController.swift */; };
+		513C5CEC232571C2003D4054 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 513C5CEA232571C2003D4054 /* MainInterface.storyboard */; };
+		513C5CF0232571C2003D4054 /* NetNewsWire iOS Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 513C5CE6232571C2003D4054 /* NetNewsWire iOS Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		513C5CFD2325749A003D4054 /* Account.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; };
+		513C5D00232574AF003D4054 /* Articles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; };
+		513C5D02232574B4003D4054 /* ArticlesDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; };
+		513C5D04232574B9003D4054 /* RSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8520DD8CF200CA8CF5 /* RSCore.framework */; };
+		513C5D06232574C0003D4054 /* RSDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */; };
+		513C5D08232574C6003D4054 /* RSParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; };
+		513C5D0A232574D2003D4054 /* RSWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */; };
+		513C5D0C232574DA003D4054 /* RSTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; };
+		513C5D0E232574E4003D4054 /* SyncDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; };
+		5142192A23522B5500E07E2C /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5142192923522B5500E07E2C /* ImageViewController.swift */; };
+		514219372352510100E07E2C /* ImageScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514219362352510100E07E2C /* ImageScrollView.swift */; };
+		5142194B2353C1CF00E07E2C /* main_mac.js in Resources */ = {isa = PBXBuildFile; fileRef = 5142194A2353C1CF00E07E2C /* main_mac.js */; };
+		514219582353C28900E07E2C /* main_ios.js in Resources */ = {isa = PBXBuildFile; fileRef = 514219572353C28900E07E2C /* main_ios.js */; };
+		5144EA2F2279FAB600D19003 /* AccountsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA2E2279FAB600D19003 /* AccountsDetailViewController.swift */; };
+		5144EA362279FC3D00D19003 /* AccountsAddLocal.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA352279FC3D00D19003 /* AccountsAddLocal.xib */; };
+		5144EA382279FC6200D19003 /* AccountsAddLocalWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA372279FC6200D19003 /* AccountsAddLocalWindowController.swift */; };
+		5144EA3B227A379E00D19003 /* ImportOPMLSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA3A227A379E00D19003 /* ImportOPMLSheet.xib */; };
+		5144EA40227A37EC00D19003 /* ImportOPMLWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA3E227A37EC00D19003 /* ImportOPMLWindowController.swift */; };
+		5144EA51227B8E4500D19003 /* AccountsFeedbinWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA4F227B8E4500D19003 /* AccountsFeedbinWindowController.swift */; };
+		5144EA52227B8E4500D19003 /* AccountsFeedbin.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA50227B8E4500D19003 /* AccountsFeedbin.xib */; };
+		5148F44B2336DB4700F8CD8B /* MasterTimelineTitleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5148F44A2336DB4700F8CD8B /* MasterTimelineTitleView.xib */; };
+		5148F4552336DB7000F8CD8B /* MasterTimelineTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5148F4542336DB7000F8CD8B /* MasterTimelineTitleView.swift */; };
+		514B7C8323205EFB00BAC947 /* RootSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514B7C8223205EFB00BAC947 /* RootSplitViewController.swift */; };
+		514B7D1F23219F3C00BAC947 /* AddControllerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514B7D1E23219F3C00BAC947 /* AddControllerType.swift */; };
+		5154368B229404D1005E1CDF /* FaviconGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F76227716200050506E /* FaviconGenerator.swift */; };
+		51554C24228B71910055115A /* SyncDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; };
+		51554C25228B71910055115A /* SyncDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51554C30228B71A10055115A /* SyncDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; };
+		51554C31228B71A10055115A /* SyncDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		515D4FC123257A3200EE1167 /* FolderTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */; };
+		515D4FCA23257CB500EE1167 /* Node-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97971ED9EFAA007D329B /* Node-Extensions.swift */; };
+		515D4FCC2325815A00EE1167 /* SafariExt.js in Resources */ = {isa = PBXBuildFile; fileRef = 515D4FCB2325815A00EE1167 /* SafariExt.js */; };
+		516A093723609A3600EAE89B /* SettingsAccountTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 516A091D23609A3600EAE89B /* SettingsAccountTableViewCell.xib */; };
+		516A09392360A2AE00EAE89B /* SettingsAccountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516A09382360A2AE00EAE89B /* SettingsAccountTableViewCell.swift */; };
+		516A093B2360A4A000EAE89B /* SettingsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 516A093A2360A4A000EAE89B /* SettingsTableViewCell.xib */; };
+		516A09402361240900EAE89B /* Account.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 516A093F2361240900EAE89B /* Account.storyboard */; };
+		516A09422361248000EAE89B /* Inspector.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 516A09412361248000EAE89B /* Inspector.storyboard */; };
+		51707439232AA97100A461A3 /* ShareFolderPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51707438232AA97100A461A3 /* ShareFolderPickerController.swift */; };
+		5170743A232AABFC00A461A3 /* FlattenedAccountFolderPickerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452812265093600C03939 /* FlattenedAccountFolderPickerData.swift */; };
+		517630042336215100E15FFF /* main.js in Resources */ = {isa = PBXBuildFile; fileRef = 517630032336215100E15FFF /* main.js */; };
+		517630052336215100E15FFF /* main.js in Resources */ = {isa = PBXBuildFile; fileRef = 517630032336215100E15FFF /* main.js */; };
+		517630232336657E00E15FFF /* ArticleViewControllerWebViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517630222336657E00E15FFF /* ArticleViewControllerWebViewProvider.swift */; };
+		5183CCD0226E1E880010922C /* NonIntrinsicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCCF226E1E880010922C /* NonIntrinsicLabel.swift */; };
+		5183CCDA226E31A50010922C /* NonIntrinsicImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCD9226E31A50010922C /* NonIntrinsicImageView.swift */; };
+		5183CCE5226F4DFA0010922C /* RefreshInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE4226F4DFA0010922C /* RefreshInterval.swift */; };
+		5183CCE6226F4E110010922C /* RefreshInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE4226F4DFA0010922C /* RefreshInterval.swift */; };
+		5183CCE8226F68D90010922C /* AccountRefreshTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE7226F68D90010922C /* AccountRefreshTimer.swift */; };
+		5183CCE9226F68D90010922C /* AccountRefreshTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE7226F68D90010922C /* AccountRefreshTimer.swift */; };
+		518651B223555EB20078E021 /* NNW3Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518651AB23555EB20078E021 /* NNW3Document.swift */; };
+		518651DA235621840078E021 /* ImageTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518651D9235621840078E021 /* ImageTransition.swift */; };
+		5186A635235EF3A800C97195 /* VibrantLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5186A634235EF3A800C97195 /* VibrantLabel.swift */; };
+		518B2EE82351B45600400001 /* NetNewsWire_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D61952029031D009BC708 /* NetNewsWire_iOSTests.swift */; };
+		51934CCB230F599B006127BE /* ThemedNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51934CC1230F5963006127BE /* ThemedNavigationController.swift */; };
+		51934CCE2310792F006127BE /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51934CCD2310792F006127BE /* ActivityManager.swift */; };
+		51938DF2231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */; };
+		51938DF3231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */; };
+		519B8D332143397200FA689C /* SharingServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519B8D322143397200FA689C /* SharingServiceDelegate.swift */; };
+		519D740623243CC0008BB345 /* RefreshInterval-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519D740523243CC0008BB345 /* RefreshInterval-Extensions.swift */; };
+		519E743D22C663F900A78E47 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519E743422C663F900A78E47 /* SceneDelegate.swift */; };
+		51A16997235E10D700EB091F /* RefreshIntervalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A1698D235E10D600EB091F /* RefreshIntervalViewController.swift */; };
+		51A16999235E10D700EB091F /* LocalAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A1698F235E10D600EB091F /* LocalAccountViewController.swift */; };
+		51A1699A235E10D700EB091F /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 51A16990235E10D600EB091F /* Settings.storyboard */; };
+		51A1699B235E10D700EB091F /* AccountInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A16991235E10D600EB091F /* AccountInspectorViewController.swift */; };
+		51A1699C235E10D700EB091F /* AddAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A16992235E10D600EB091F /* AddAccountViewController.swift */; };
+		51A1699D235E10D700EB091F /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A16993235E10D600EB091F /* SettingsViewController.swift */; };
+		51A1699F235E10D700EB091F /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A16995235E10D600EB091F /* AboutViewController.swift */; };
+		51A169A0235E10D700EB091F /* FeedbinAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A16996235E10D700EB091F /* FeedbinAccountViewController.swift */; };
+		51AF460E232488C6001742EF /* Account-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AF460D232488C6001742EF /* Account-Extensions.swift */; };
+		51B62E68233186730085F949 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B62E67233186730085F949 /* AvatarView.swift */; };
+		51BB7C272335A8E5008E8144 /* ArticleActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BB7C262335A8E5008E8144 /* ArticleActivityItemSource.swift */; };
+		51BB7C312335ACDE008E8144 /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = 51BB7C302335ACDE008E8144 /* page.html */; };
+		51C451A9226377C200C03939 /* ArticlesDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; };
+		51C451AA226377C200C03939 /* ArticlesDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451B9226377C900C03939 /* Articles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; };
+		51C451BA226377C900C03939 /* Articles.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451BD226377D000C03939 /* Account.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; };
+		51C451BE226377D000C03939 /* Account.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451D22264C7F200C03939 /* RSWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */; };
+		51C451D32264C7F200C03939 /* RSWeb.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451E02264C7F900C03939 /* RSTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; };
+		51C451E12264C7F900C03939 /* RSTree.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451E42264C80600C03939 /* RSParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; };
+		51C451E52264C80600C03939 /* RSParser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451E82264C81000C03939 /* RSDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */; };
+		51C451E92264C81000C03939 /* RSDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451EC2264C81B00C03939 /* RSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8520DD8CF200CA8CF5 /* RSCore.framework */; };
+		51C451ED2264C81B00C03939 /* RSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8520DD8CF200CA8CF5 /* RSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451F02264C83100C03939 /* ArticlesDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; };
+		51C451F12264C83100C03939 /* ArticlesDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451F42264C83900C03939 /* Articles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; };
+		51C451F52264C83900C03939 /* Articles.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C451F82264C83E00C03939 /* Account.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; };
+		51C451F92264C83E00C03939 /* Account.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		51C45258226508CF00C03939 /* AppAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45254226507D200C03939 /* AppAssets.swift */; };
+		51C45259226508D300C03939 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45255226507D200C03939 /* AppDefaults.swift */; };
+		51C4525A226508D600C03939 /* UIStoryboard-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4524E226506F400C03939 /* UIStoryboard-Extensions.swift */; };
+		51C4525C226508DF00C03939 /* String-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45250226506F400C03939 /* String-Extensions.swift */; };
+		51C45268226508F600C03939 /* MasterFeedUnreadCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45261226508F600C03939 /* MasterFeedUnreadCountView.swift */; };
+		51C45269226508F600C03939 /* MasterFeedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45262226508F600C03939 /* MasterFeedTableViewCell.swift */; };
+		51C4526A226508F600C03939 /* MasterFeedTableViewCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45263226508F600C03939 /* MasterFeedTableViewCellLayout.swift */; };
+		51C4526B226508F600C03939 /* MasterFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C45264226508F600C03939 /* MasterFeedViewController.swift */; };
+		51C452762265091600C03939 /* MasterTimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4526E2265091600C03939 /* MasterTimelineViewController.swift */; };
+		51C452772265091600C03939 /* MultilineUILabelSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452702265091600C03939 /* MultilineUILabelSizer.swift */; };
+		51C452782265091600C03939 /* MasterTimelineCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452712265091600C03939 /* MasterTimelineCellData.swift */; };
+		51C452792265091600C03939 /* MasterTimelineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452722265091600C03939 /* MasterTimelineTableViewCell.swift */; };
+		51C4527B2265091600C03939 /* MasterUnreadIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452742265091600C03939 /* MasterUnreadIndicatorView.swift */; };
+		51C4527C2265091600C03939 /* MasterTimelineDefaultCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452752265091600C03939 /* MasterTimelineDefaultCellLayout.swift */; };
+		51C4527F2265092C00C03939 /* ArticleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4527E2265092C00C03939 /* ArticleViewController.swift */; };
+		51C452852265093600C03939 /* FlattenedAccountFolderPickerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452812265093600C03939 /* FlattenedAccountFolderPickerData.swift */; };
+		51C452862265093600C03939 /* Add.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 51C452822265093600C03939 /* Add.storyboard */; };
+		51C452882265093600C03939 /* AddFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C452842265093600C03939 /* AddFeedViewController.swift */; };
+		51C4528D2265095F00C03939 /* AddFolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C4528B2265095F00C03939 /* AddFolderViewController.swift */; };
+		51C4528E2265099C00C03939 /* SmartFeedsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CC88171FE59CBF00644329 /* SmartFeedsController.swift */; };
+		51C4528F226509BD00C03939 /* UnreadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5391FC2308B00998D64 /* UnreadFeed.swift */; };
+		51C45290226509C100C03939 /* PseudoFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5351FC22FCB00998D64 /* PseudoFeed.swift */; };
+		51C45291226509C800C03939 /* SmartFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7C01FC2488C00854A1F /* SmartFeed.swift */; };
+		51C45292226509C800C03939 /* TodayFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */; };
+		51C45293226509C800C03939 /* StarredFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */; };
+		51C45294226509C800C03939 /* SearchFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */; };
+		51C45296226509D300C03939 /* OPMLExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8444C8F11FED81840051386C /* OPMLExporter.swift */; };
+		51C45297226509E300C03939 /* DefaultFeedsImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97591ED9EB0D007D329B /* DefaultFeedsImporter.swift */; };
+		51C4529922650A0000C03939 /* ArticleStylesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97881ED9ECEF007D329B /* ArticleStylesManager.swift */; };
+		51C4529A22650A0400C03939 /* ArticleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97871ED9ECEF007D329B /* ArticleStyle.swift */; };
+		51C4529B22650A1000C03939 /* FaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848F6AE41FC29CFA002D422E /* FaviconDownloader.swift */; };
+		51C4529C22650A1000C03939 /* SingleFaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29081FC74B8E007B49E3 /* SingleFaviconDownloader.swift */; };
+		51C4529D22650A1000C03939 /* FaviconURLFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */; };
+		51C4529E22650A1900C03939 /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845213221FCA5B10003B6E93 /* ImageDownloader.swift */; };
+		51C4529F22650A1900C03939 /* AuthorAvatarDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E850851FCB60CE0072EA88 /* AuthorAvatarDownloader.swift */; };
+		51C452A022650A1900C03939 /* FeedIconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611891FCB67AA0086A189 /* FeedIconDownloader.swift */; };
+		51C452A222650A1900C03939 /* RSHTMLMetadata+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611A11FCB769D0086A189 /* RSHTMLMetadata+Extension.swift */; };
+		51C452A322650A1E00C03939 /* HTMLMetadataDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426119D1FCB6ED40086A189 /* HTMLMetadataDownloader.swift */; };
+		51C452A422650A2D00C03939 /* ArticleUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97581ED9EB0D007D329B /* ArticleUtilities.swift */; };
+		51C452A522650A2D00C03939 /* SmallIconProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84411E701FE5FBFA004B527F /* SmallIconProvider.swift */; };
+		51C452A622650A3500C03939 /* Node-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97971ED9EFAA007D329B /* Node-Extensions.swift */; };
+		51C452A722650A3D00C03939 /* RSImage-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51126DA3225FDE2F00722696 /* RSImage-Extensions.swift */; };
+		51C452A922650DC600C03939 /* ArticleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A977D1ED9EC42007D329B /* ArticleRenderer.swift */; };
+		51C452AB22650DC600C03939 /* template.html in Resources */ = {isa = PBXBuildFile; fileRef = 848362FE2262A30E00DA1D35 /* template.html */; };
+		51C452AC22650FD200C03939 /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E45CD1ED8C308000A8B52 /* AppNotifications.swift */; };
+		51C452AE2265104D00C03939 /* ArticleStringFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97731ED9EC04007D329B /* ArticleStringFormatter.swift */; };
+		51C452AF2265108300C03939 /* ArticleArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F204DF1FAACBB30076E152 /* ArticleArray.swift */; };
+		51C452B42265141B00C03939 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51C452B32265141B00C03939 /* WebKit.framework */; };
+		51C452B82265178500C03939 /* styleSheet.css in Resources */ = {isa = PBXBuildFile; fileRef = 51C452B72265178500C03939 /* styleSheet.css */; };
+		51CC9B3E231720B2000E842F /* MasterFeedDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CC9B3D231720B2000E842F /* MasterFeedDataSource.swift */; };
+		51CE1C0923621EDA005548FC /* RefreshProgressView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51CE1C0823621EDA005548FC /* RefreshProgressView.xib */; };
+		51CE1C0B23622007005548FC /* RefreshProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CE1C0A23622006005548FC /* RefreshProgressView.swift */; };
+		51CE1C712367721A005548FC /* testURLsOfCurrentArticle.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADB213660A100CF2DE4 /* testURLsOfCurrentArticle.applescript */; };
+		51D5948722668EFA00DFC836 /* MarkStatusCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84702AA31FA27AC0006B8943 /* MarkStatusCommand.swift */; };
+		51D6A5BC23199C85001C27D8 /* MasterTimelineDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D6A5BB23199C85001C27D8 /* MasterTimelineDataSource.swift */; };
+		51D87EE12311D34700E63F03 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D87EE02311D34700E63F03 /* ActivityType.swift */; };
+		51E3EB33229AB02C00645299 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E3EB32229AB02C00645299 /* ErrorHandler.swift */; };
+		51E3EB3D229AB08300645299 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E3EB3C229AB08300645299 /* ErrorHandler.swift */; };
+		51E595A5228CC36500FCC42B /* ArticleStatusSyncTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E595A4228CC36500FCC42B /* ArticleStatusSyncTimer.swift */; };
+		51E595A6228CC36500FCC42B /* ArticleStatusSyncTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E595A4228CC36500FCC42B /* ArticleStatusSyncTimer.swift */; };
+		51EAED96231363EF00A9EEE3 /* NonIntrinsicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EAED95231363EF00A9EEE3 /* NonIntrinsicButton.swift */; };
+		51EC114C2149FE3300B296E3 /* FolderTreeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EC114B2149FE3300B296E3 /* FolderTreeMenu.swift */; };
+		51EF0F77227716200050506E /* FaviconGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F76227716200050506E /* FaviconGenerator.swift */; };
+		51EF0F79227716380050506E /* ColorHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F78227716380050506E /* ColorHash.swift */; };
+		51EF0F7A22771B890050506E /* ColorHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F78227716380050506E /* ColorHash.swift */; };
+		51EF0F7E2277A57D0050506E /* MasterTimelineAccessibilityCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F7D2277A57D0050506E /* MasterTimelineAccessibilityCellLayout.swift */; };
+		51EF0F802277A8330050506E /* MasterTimelineCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F7F2277A8330050506E /* MasterTimelineCellLayout.swift */; };
+		51EF0F8E2279C9260050506E /* AccountsAdd.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51EF0F8D2279C9260050506E /* AccountsAdd.xib */; };
+		51EF0F902279C9500050506E /* AccountsAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F8F2279C9500050506E /* AccountsAddViewController.swift */; };
+		51EF0F922279CA620050506E /* AccountsAddTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F912279CA620050506E /* AccountsAddTableCellView.swift */; };
+		51F85BEB22724CB600C787DC /* About.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 51F85BEA22724CB600C787DC /* About.rtf */; };
+		51F85BED227251DF00C787DC /* Acknowledgments.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 51F85BEC227251DF00C787DC /* Acknowledgments.rtf */; };
+		51F85BEF2272520B00C787DC /* Thanks.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 51F85BEE2272520B00C787DC /* Thanks.rtf */; };
+		51F85BF12272524100C787DC /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 51F85BF02272524100C787DC /* Credits.rtf */; };
+		51F85BF32272531500C787DC /* Dedication.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 51F85BF22272531500C787DC /* Dedication.rtf */; };
+		51F85BF52273625800C787DC /* Bundle-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BF42273625800C787DC /* Bundle-Extensions.swift */; };
+		51F85BF722749FA100C787DC /* UIFont-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BF622749FA100C787DC /* UIFont-Extensions.swift */; };
+		51F85BF92274AA7B00C787DC /* UIBarButtonItem-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BF82274AA7B00C787DC /* UIBarButtonItem-Extensions.swift */; };
+		51F85BFB2275D85000C787DC /* Array-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BFA2275D85000C787DC /* Array-Extensions.swift */; };
+		51F85BFD2275DCA800C787DC /* SingleLineUILabelSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F85BFC2275DCA800C787DC /* SingleLineUILabelSizer.swift */; };
+		51FA73A42332BE110090D516 /* ArticleExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A32332BE110090D516 /* ArticleExtractor.swift */; };
+		51FA73A52332BE110090D516 /* ArticleExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A32332BE110090D516 /* ArticleExtractor.swift */; };
+		51FA73A72332BE880090D516 /* ExtractedArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A62332BE880090D516 /* ExtractedArticle.swift */; };
+		51FA73A82332BE880090D516 /* ExtractedArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A62332BE880090D516 /* ExtractedArticle.swift */; };
+		51FA73AA2332C2FD0090D516 /* ArticleExtractorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A92332C2FD0090D516 /* ArticleExtractorConfig.swift */; };
+		51FA73AB2332C2FD0090D516 /* ArticleExtractorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A92332C2FD0090D516 /* ArticleExtractorConfig.swift */; };
+		51FA73B72332D5F70090D516 /* ArticleExtractorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73B62332D5F70090D516 /* ArticleExtractorButton.swift */; };
+		51FD40C72341555A00880194 /* UIImage-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FD40BD2341555600880194 /* UIImage-Extensions.swift */; };
+		51FD413B2342BD0500880194 /* MasterTimelineUnreadCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FD413A2342BD0500880194 /* MasterTimelineUnreadCountView.swift */; };
+		51FE10032345529D0056195D /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE10022345529D0056195D /* UserNotificationManager.swift */; };
+		51FE10042345529D0056195D /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE10022345529D0056195D /* UserNotificationManager.swift */; };
+		51FE10092346739D0056195D /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D87EE02311D34700E63F03 /* ActivityType.swift */; };
+		51FE100A234673A00056195D /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51934CCD2310792F006127BE /* ActivityManager.swift */; };
+		51FFF0C4235EE8E5002762AA /* VibrantButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FFF0C3235EE8E5002762AA /* VibrantButton.swift */; };
+		55E15BCB229D65A900D6602A /* AccountsReaderAPI.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */; };
+		55E15BCC229D65A900D6602A /* AccountsReaderAPIWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */; };
+		5F323809231DF9F000706F6B /* VibrantTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F323808231DF9F000706F6B /* VibrantTableViewCell.swift */; };
+		6581C73820CED60100F4AD34 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */; };
+		6581C73A20CED60100F4AD34 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73920CED60100F4AD34 /* SafariExtensionViewController.swift */; };
+		6581C73D20CED60100F4AD34 /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6581C73B20CED60100F4AD34 /* SafariExtensionViewController.xib */; };
+		6581C74020CED60100F4AD34 /* netnewswire-subscribe-to-feed.js in Resources */ = {isa = PBXBuildFile; fileRef = 6581C73F20CED60100F4AD34 /* netnewswire-subscribe-to-feed.js */; };
+		6581C74220CED60100F4AD34 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 6581C74120CED60100F4AD34 /* ToolbarItemIcon.pdf */; };
+		65ED3FB7235DEF6C0081F399 /* ArticleArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F204DF1FAACBB30076E152 /* ArticleArray.swift */; };
+		65ED3FB8235DEF6C0081F399 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B937121C8C5540038DC0D /* CrashReporter.swift */; };
+		65ED3FB9235DEF6C0081F399 /* TimelineAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847CD6C9232F4CBF00FAC46D /* TimelineAvatarView.swift */; };
+		65ED3FBA235DEF6C0081F399 /* ArticleExtractorConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A92332C2FD0090D516 /* ArticleExtractorConfig.swift */; };
+		65ED3FBB235DEF6C0081F399 /* InspectorWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BBB12C20142A4700F054F5 /* InspectorWindowController.swift */; };
+		65ED3FBC235DEF6C0081F399 /* ColorHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F78227716380050506E /* ColorHash.swift */; };
+		65ED3FBD235DEF6C0081F399 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E46C7C1F75EF7B005ECFB3 /* AppDefaults.swift */; };
+		65ED3FBE235DEF6C0081F399 /* Account+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907D962004B7EB005947E5 /* Account+Scriptability.swift */; };
+		65ED3FBF235DEF6C0081F399 /* NothingInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA4D20145E7300980E11 /* NothingInspectorViewController.swift */; };
+		65ED3FC0235DEF6C0081F399 /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E45CD1ED8C308000A8B52 /* AppNotifications.swift */; };
+		65ED3FC1235DEF6C0081F399 /* TimelineKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B5A1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift */; };
+		65ED3FC2235DEF6C0081F399 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E45DC1ED8C54B000A8B52 /* Browser.swift */; };
+		65ED3FC3235DEF6C0081F399 /* DetailWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84216D0222128B9D0049B9B9 /* DetailWebViewController.swift */; };
+		65ED3FC4235DEF6C0081F399 /* OPMLExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8444C8F11FED81840051386C /* OPMLExporter.swift */; };
+		65ED3FC5235DEF6C0081F399 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A975D1ED9EB72007D329B /* MainWindowController.swift */; };
+		65ED3FC6235DEF6C0081F399 /* UnreadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5391FC2308B00998D64 /* UnreadFeed.swift */; };
+		65ED3FC7235DEF6C0081F399 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513228F2233037620033D4ED /* Reachability.swift */; };
+		65ED3FC8235DEF6C0081F399 /* SidebarCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29211FC9251E007B49E3 /* SidebarCellLayout.swift */; };
+		65ED3FC9235DEF6C0081F399 /* SmartFeedPasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EB92031649C00BC20B7 /* SmartFeedPasteboardWriter.swift */; };
+		65ED3FCA235DEF6C0081F399 /* SmartFeedsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CC88171FE59CBF00644329 /* SmartFeedsController.swift */; };
+		65ED3FCB235DEF6C0081F399 /* SidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97621ED9EB96007D329B /* SidebarViewController.swift */; };
+		65ED3FCC235DEF6C0081F399 /* AccountsFeedlyWebWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA33BB72318F8C10097B644 /* AccountsFeedlyWebWindowController.swift */; };
+		65ED3FCD235DEF6C0081F399 /* SidebarOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97601ED9EB96007D329B /* SidebarOutlineView.swift */; };
+		65ED3FCE235DEF6C0081F399 /* DetailKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5127B236222B4849006D641D /* DetailKeyboardDelegate.swift */; };
+		65ED3FCF235DEF6C0081F399 /* TimelineContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD9822153B6B008CE1BF /* TimelineContainerView.swift */; };
+		65ED3FD0235DEF6C0081F399 /* Author+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2678B20130ECF00A8D3C0 /* Author+Scriptability.swift */; };
+		65ED3FD1235DEF6C0081F399 /* PseudoFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5351FC22FCB00998D64 /* PseudoFeed.swift */; };
+		65ED3FD2235DEF6C0081F399 /* AccountsAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F8F2279C9500050506E /* AccountsAddViewController.swift */; };
+		65ED3FD3235DEF6C0081F399 /* NSScriptCommand+NetNewsWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */; };
+		65ED3FD4235DEF6C0081F399 /* Article+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D553737C20186C1F006D8857 /* Article+Scriptability.swift */; };
+		65ED3FD5235DEF6C0081F399 /* SmartFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7C01FC2488C00854A1F /* SmartFeed.swift */; };
+		65ED3FD6235DEF6C0081F399 /* MarkStatusCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84702AA31FA27AC0006B8943 /* MarkStatusCommand.swift */; };
+		65ED3FD7235DEF6C0081F399 /* NSApplication+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907D7E2004AC00005947E5 /* NSApplication+Scriptability.swift */; };
+		65ED3FD8235DEF6C0081F399 /* NSView-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD9B22153BD7008CE1BF /* NSView-Extensions.swift */; };
+		65ED3FD9235DEF6C0081F399 /* SidebarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A979E1ED9F130007D329B /* SidebarCell.swift */; };
+		65ED3FDA235DEF6C0081F399 /* ArticleStatusSyncTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E595A4228CC36500FCC42B /* ArticleStatusSyncTimer.swift */; };
+		65ED3FDB235DEF6C0081F399 /* FeedTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97611ED9EB96007D329B /* FeedTreeControllerDelegate.swift */; };
+		65ED3FDC235DEF6C0081F399 /* UnreadCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97631ED9EB96007D329B /* UnreadCountView.swift */; };
+		65ED3FDD235DEF6C0081F399 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D87EE02311D34700E63F03 /* ActivityType.swift */; };
+		65ED3FDE235DEF6C0081F399 /* CrashReportWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840BEE4021D70E64009BBAFA /* CrashReportWindowController.swift */; };
+		65ED3FDF235DEF6C0081F399 /* FeedIconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611891FCB67AA0086A189 /* FeedIconDownloader.swift */; };
+		65ED3FE0235DEF6C0081F399 /* AccountsControlsBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7122629E1200D921D6 /* AccountsControlsBackgroundView.swift */; };
+		65ED3FE1235DEF6C0081F399 /* MarkCommandValidationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84162A142038C12C00035290 /* MarkCommandValidationStatus.swift */; };
+		65ED3FE2235DEF6C0081F399 /* ArticlePasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E95D231FB1087500552D99 /* ArticlePasteboardWriter.swift */; };
+		65ED3FE3235DEF6C0081F399 /* ArticleUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97581ED9EB0D007D329B /* ArticleUtilities.swift */; };
+		65ED3FE4235DEF6C0081F399 /* NNW3OpenPanelAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849ADEE7235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift */; };
+		65ED3FE5235DEF6C0081F399 /* DefaultFeedsImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97591ED9EB0D007D329B /* DefaultFeedsImporter.swift */; };
+		65ED3FE6235DEF6C0081F399 /* RenameWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A37CB4201ECD610087C5AF /* RenameWindowController.swift */; };
+		65ED3FE7235DEF6C0081F399 /* SendToMicroBlogCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A14FF220048CA70046AD9A /* SendToMicroBlogCommand.swift */; };
+		65ED3FE8235DEF6C0081F399 /* ArticleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97871ED9ECEF007D329B /* ArticleStyle.swift */; };
+		65ED3FE9235DEF6C0081F399 /* FaviconURLFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */; };
+		65ED3FEA235DEF6C0081F399 /* SidebarViewController+ContextualMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B7178B201E66580091657D /* SidebarViewController+ContextualMenus.swift */; };
+		65ED3FEB235DEF6C0081F399 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		65ED3FEC235DEF6C0081F399 /* RSHTMLMetadata+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611A11FCB769D0086A189 /* RSHTMLMetadata+Extension.swift */; };
+		65ED3FED235DEF6C0081F399 /* SendToMarsEditCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1500420048DDF0046AD9A /* SendToMarsEditCommand.swift */; };
+		65ED3FEE235DEF6C0081F399 /* UserNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE10022345529D0056195D /* UserNotificationManager.swift */; };
+		65ED3FEF235DEF6C0081F399 /* ScriptingObjectContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907DB12004BB37005947E5 /* ScriptingObjectContainer.swift */; };
+		65ED3FF0235DEF6C0081F399 /* ArticleStylesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97881ED9ECEF007D329B /* ArticleStylesManager.swift */; };
+		65ED3FF1235DEF6C0081F399 /* DetailContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD892213E0E3008CE1BF /* DetailContainerView.swift */; };
+		65ED3FF2235DEF6C0081F399 /* SharingServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519B8D322143397200FA689C /* SharingServiceDelegate.swift */; };
+		65ED3FF3235DEF6C0081F399 /* ArticleSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */; };
+		65ED3FF4235DEF6C0081F399 /* TimelineViewController+ContextualMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E8E0DA202EC49300562D8F /* TimelineViewController+ContextualMenus.swift */; };
+		65ED3FF5235DEF6C0081F399 /* ArticleStringFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97731ED9EC04007D329B /* ArticleStringFormatter.swift */; };
+		65ED3FF6235DEF6C0081F399 /* MultilineTextFieldSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E185C2203BB12600F69BFA /* MultilineTextFieldSizer.swift */; };
+		65ED3FF7235DEF6C0081F399 /* SearchFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */; };
+		65ED3FF8235DEF6C0081F399 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E3EB32229AB02C00645299 /* ErrorHandler.swift */; };
+		65ED3FF9235DEF6C0081F399 /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51934CCD2310792F006127BE /* ActivityManager.swift */; };
+		65ED3FFA235DEF6C0081F399 /* FeedInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8472058020142E8900AD578B /* FeedInspectorViewController.swift */; };
+		65ED3FFB235DEF6C0081F399 /* AccountsReaderAPIWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */; };
+		65ED3FFC235DEF6C0081F399 /* AccountsAddLocalWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA372279FC6200D19003 /* AccountsAddLocalWindowController.swift */; };
+		65ED3FFD235DEF6C0081F399 /* PasteboardFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EA92031617300BC20B7 /* PasteboardFolder.swift */; };
+		65ED3FFE235DEF6C0081F399 /* AccountsFeedbinWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA4F227B8E4500D19003 /* AccountsFeedbinWindowController.swift */; };
+		65ED3FFF235DEF6C0081F399 /* SidebarOutlineDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EBB2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift */; };
+		65ED4000235DEF6C0081F399 /* SidebarCellAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29231FC9255E007B49E3 /* SidebarCellAppearance.swift */; };
+		65ED4001235DEF6C0081F399 /* StarredFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */; };
+		65ED4002235DEF6C0081F399 /* FaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848F6AE41FC29CFA002D422E /* FaviconDownloader.swift */; };
+		65ED4003235DEF6C0081F399 /* AdvancedPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6B22629E1200D921D6 /* AdvancedPreferencesViewController.swift */; };
+		65ED4004235DEF6C0081F399 /* SharingServicePickerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849EE72020391F560082A1EA /* SharingServicePickerDelegate.swift */; };
+		65ED4005235DEF6C0081F399 /* Node-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97971ED9EFAA007D329B /* Node-Extensions.swift */; };
+		65ED4006235DEF6C0081F399 /* AppAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849EE70E203919360082A1EA /* AppAssets.swift */; };
+		65ED4007235DEF6C0081F399 /* AddFeedController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97511ED9EAC0007D329B /* AddFeedController.swift */; };
+		65ED4008235DEF6C0081F399 /* AccountRefreshTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE7226F68D90010922C /* AccountRefreshTimer.swift */; };
+		65ED4009235DEF6C0081F399 /* SidebarStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97821ED9EC63007D329B /* SidebarStatusBarView.swift */; };
+		65ED400A235DEF6C0081F399 /* SearchTimelineFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */; };
+		65ED400B235DEF6C0081F399 /* TodayFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */; };
+		65ED400C235DEF6C0081F399 /* FolderInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA5D20145E9200980E11 /* FolderInspectorViewController.swift */; };
+		65ED400D235DEF6C0081F399 /* SmartFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */; };
+		65ED400E235DEF6C0081F399 /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845213221FCA5B10003B6E93 /* ImageDownloader.swift */; };
+		65ED400F235DEF6C0081F399 /* ArticleExtractorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73B62332D5F70090D516 /* ArticleExtractorButton.swift */; };
+		65ED4010235DEF6C0081F399 /* AccountsAddTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F912279CA620050506E /* AccountsAddTableCellView.swift */; };
+		65ED4011235DEF6C0081F399 /* AddFolderWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97421ED9EAA9007D329B /* AddFolderWindowController.swift */; };
+		65ED4012235DEF6C0081F399 /* TimelineContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DDA422168C62008CE1BF /* TimelineContainerViewController.swift */; };
+		65ED4013235DEF6C0081F399 /* MainWIndowKeyboardHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B661FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift */; };
+		65ED4014235DEF6C0081F399 /* PasteboardFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D578D21543519005FFAD5 /* PasteboardFeed.swift */; };
+		65ED4015235DEF6C0081F399 /* AccountsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA2E2279FAB600D19003 /* AccountsDetailViewController.swift */; };
+		65ED4016235DEF6C0081F399 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A977E1ED9EC42007D329B /* DetailViewController.swift */; };
+		65ED4017235DEF6C0081F399 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6622629B3900D921D6 /* AppDelegate.swift */; };
+		65ED4018235DEF6C0081F399 /* AccountsTableViewBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7022629E1200D921D6 /* AccountsTableViewBackgroundView.swift */; };
+		65ED4019235DEF6C0081F399 /* FetchRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCAE22BC8C35007694F0 /* FetchRequestOperation.swift */; };
+		65ED401A235DEF6C0081F399 /* HTMLMetadataDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426119D1FCB6ED40086A189 /* HTMLMetadataDownloader.swift */; };
+		65ED401B235DEF6C0081F399 /* TimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A976B1ED9EBC8007D329B /* TimelineViewController.swift */; };
+		65ED401C235DEF6C0081F399 /* FaviconGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF0F76227716200050506E /* FaviconGenerator.swift */; };
+		65ED401D235DEF6C0081F399 /* RefreshInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183CCE4226F4DFA0010922C /* RefreshInterval.swift */; };
+		65ED401E235DEF6C0081F399 /* TimelineCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97711ED9EC04007D329B /* TimelineCellData.swift */; };
+		65ED401F235DEF6C0081F399 /* BuiltinSmartFeedInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA5F20145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift */; };
+		65ED4020235DEF6C0081F399 /* AppDelegate+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */; };
+		65ED4021235DEF6C0081F399 /* NNW3Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518651AB23555EB20078E021 /* NNW3Document.swift */; };
+		65ED4022235DEF6C0081F399 /* ScriptingObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */; };
+		65ED4023235DEF6C0081F399 /* Folder+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */; };
+		65ED4024235DEF6C0081F399 /* TimelineCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97721ED9EC04007D329B /* TimelineCellLayout.swift */; };
+		65ED4025235DEF6C0081F399 /* DetailWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E8E0EA202F693600562D8F /* DetailWebView.swift */; };
+		65ED4026235DEF6C0081F399 /* TimelineTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97691ED9EBC8007D329B /* TimelineTableRowView.swift */; };
+		65ED4027235DEF6C0081F399 /* UnreadIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97751ED9EC04007D329B /* UnreadIndicatorView.swift */; };
+		65ED4028235DEF6C0081F399 /* ExtractedArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A62332BE880090D516 /* ExtractedArticle.swift */; };
+		65ED4029235DEF6C0081F399 /* DeleteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B99C9C1FAE83C600ECDEDB /* DeleteCommand.swift */; };
+		65ED402A235DEF6C0081F399 /* AddFeedWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97521ED9EAC0007D329B /* AddFeedWindowController.swift */; };
+		65ED402B235DEF6C0081F399 /* ImportOPMLWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5144EA3E227A37EC00D19003 /* ImportOPMLWindowController.swift */; };
+		65ED402C235DEF6C0081F399 /* TimelineTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A976A1ED9EBC8007D329B /* TimelineTableView.swift */; };
+		65ED402D235DEF6C0081F399 /* DetailStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D52E941FE588BB00D14F5B /* DetailStatusBarView.swift */; };
+		65ED402E235DEF6C0081F399 /* MainWindowController+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */; };
+		65ED402F235DEF6C0081F399 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6E22629E1200D921D6 /* PreferencesWindowController.swift */; };
+		65ED4030235DEF6C0081F399 /* SmallIconProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84411E701FE5FBFA004B527F /* SmallIconProvider.swift */; };
+		65ED4031235DEF6C0081F399 /* ArticleExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FA73A32332BE110090D516 /* ArticleExtractor.swift */; };
+		65ED4032235DEF6C0081F399 /* FetchRequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCA322BC8C08007694F0 /* FetchRequestQueue.swift */; };
+		65ED4033235DEF6C0081F399 /* SidebarKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B581FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift */; };
+		65ED4034235DEF6C0081F399 /* AccountsPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7222629E1200D921D6 /* AccountsPreferencesViewController.swift */; };
+		65ED4035235DEF6C0081F399 /* FolderTreeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EC114B2149FE3300B296E3 /* FolderTreeMenu.swift */; };
+		65ED4036235DEF6C0081F399 /* NNW3ImportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849ADEE02359817D000E1B81 /* NNW3ImportController.swift */; };
+		65ED4037235DEF6C0081F399 /* FolderTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */; };
+		65ED4038235DEF6C0081F399 /* RSImage-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51126DA3225FDE2F00722696 /* RSImage-Extensions.swift */; };
+		65ED4039235DEF6C0081F399 /* SingleFaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29081FC74B8E007B49E3 /* SingleFaviconDownloader.swift */; };
+		65ED403A235DEF6C0081F399 /* Feed+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */; };
+		65ED403B235DEF6C0081F399 /* AuthorAvatarDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E850851FCB60CE0072EA88 /* AuthorAvatarDownloader.swift */; };
+		65ED403C235DEF6C0081F399 /* SingleLineTextFieldSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E185B2203B74E500F69BFA /* SingleLineTextFieldSizer.swift */; };
+		65ED403D235DEF6C0081F399 /* TimelineTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97741ED9EC04007D329B /* TimelineTableCellView.swift */; };
+		65ED403E235DEF6C0081F399 /* TimelineCellAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97701ED9EC04007D329B /* TimelineCellAppearance.swift */; };
+		65ED403F235DEF6C0081F399 /* ArticleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A977D1ED9EC42007D329B /* ArticleRenderer.swift */; };
+		65ED4040235DEF6C0081F399 /* GeneralPrefencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6D22629E1200D921D6 /* GeneralPrefencesViewController.swift */; };
+		65ED4043235DEF6C0081F399 /* RSWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */; };
+		65ED4044235DEF6C0081F399 /* RSDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */; };
+		65ED4045235DEF6C0081F399 /* RSTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; };
+		65ED4046235DEF6C0081F399 /* ArticlesDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; };
+		65ED4047235DEF6C0081F399 /* RSParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; };
+		65ED4048235DEF6C0081F399 /* Account.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; };
+		65ED4049235DEF6C0081F399 /* Articles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; };
+		65ED404A235DEF6C0081F399 /* RSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8120DD8CF200CA8CF5 /* RSCore.framework */; };
+		65ED404B235DEF6C0081F399 /* SyncDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; };
+		65ED404E235DEF6C0081F399 /* NNW3OpenPanelAccessoryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 849ADEE523598189000E1B81 /* NNW3OpenPanelAccessoryView.xib */; };
+		65ED404F235DEF6C0081F399 /* GlobalKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B641FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist */; };
+		65ED4050235DEF6C0081F399 /* DetailKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5127B237222B4849006D641D /* DetailKeyboardShortcuts.plist */; };
+		65ED4051235DEF6C0081F399 /* TimelineKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 845479871FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist */; };
+		65ED4052235DEF6C0081F399 /* template.html in Resources */ = {isa = PBXBuildFile; fileRef = 848362FE2262A30E00DA1D35 /* template.html */; };
+		65ED4053235DEF6C0081F399 /* AccountsFeedlyWeb.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9EA33BB82318F8C10097B644 /* AccountsFeedlyWeb.xib */; };
+		65ED4054235DEF6C0081F399 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 848363062262A3DD00DA1D35 /* Main.storyboard */; };
+		65ED4055235DEF6C0081F399 /* AccountsAdd.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51EF0F8D2279C9260050506E /* AccountsAdd.xib */; };
+		65ED4056235DEF6C0081F399 /* NetNewsWire.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8A22629E8F00D921D6 /* NetNewsWire.sdef */; };
+		65ED4057235DEF6C0081F399 /* AccountsDetail.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC7422629E1200D921D6 /* AccountsDetail.xib */; };
+		65ED4058235DEF6C0081F399 /* main.js in Resources */ = {isa = PBXBuildFile; fileRef = 517630032336215100E15FFF /* main.js */; };
+		65ED4059235DEF6C0081F399 /* AccountsAddLocal.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA352279FC3D00D19003 /* AccountsAddLocal.xib */; };
+		65ED405A235DEF6C0081F399 /* main_mac.js in Resources */ = {isa = PBXBuildFile; fileRef = 5142194A2353C1CF00E07E2C /* main_mac.js */; };
+		65ED405B235DEF6C0081F399 /* KeyboardShortcuts.html in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8722629E8F00D921D6 /* KeyboardShortcuts.html */; };
+		65ED405C235DEF6C0081F399 /* ImportOPMLSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA3A227A379E00D19003 /* ImportOPMLSheet.xib */; };
+		65ED405D235DEF6C0081F399 /* SidebarKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B681FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist */; };
+		65ED405E235DEF6C0081F399 /* DefaultFeeds.opml in Resources */ = {isa = PBXBuildFile; fileRef = 84A3EE52223B667F00557320 /* DefaultFeeds.opml */; };
+		65ED405F235DEF6C0081F399 /* Preferences.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8022629E4800D921D6 /* Preferences.storyboard */; };
+		65ED4060235DEF6C0081F399 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		65ED4061235DEF6C0081F399 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 849C64671ED37A5D003D8FC0 /* Assets.xcassets */; };
+		65ED4062235DEF6C0081F399 /* styleSheet.css in Resources */ = {isa = PBXBuildFile; fileRef = 848362FC2262A30800DA1D35 /* styleSheet.css */; };
+		65ED4063235DEF6C0081F399 /* RenameSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363092262A3F000DA1D35 /* RenameSheet.xib */; };
+		65ED4064235DEF6C0081F399 /* AddFolderSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363032262A3CC00DA1D35 /* AddFolderSheet.xib */; };
+		65ED4065235DEF6C0081F399 /* AccountsFeedbin.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5144EA50227B8E4500D19003 /* AccountsFeedbin.xib */; };
+		65ED4066235DEF6C0081F399 /* TimelineTableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8405DDA122168920008CE1BF /* TimelineTableView.xib */; };
+		65ED4067235DEF6C0081F399 /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = B528F81D23333C7E00E735DD /* page.html */; };
+		65ED4068235DEF6C0081F399 /* MainWindow.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8483630C2262A3FE00DA1D35 /* MainWindow.storyboard */; };
+		65ED4069235DEF6C0081F399 /* AccountsReaderAPI.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */; };
+		65ED406A235DEF6C0081F399 /* newsfoot.js in Resources */ = {isa = PBXBuildFile; fileRef = 49F40DEF2335B71000552BF4 /* newsfoot.js */; };
+		65ED406B235DEF6C0081F399 /* CrashReporterWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84BAE64821CEDAF20046DB56 /* CrashReporterWindow.xib */; };
+		65ED406C235DEF6C0081F399 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8922629E8F00D921D6 /* Credits.rtf */; };
+		65ED406D235DEF6C0081F399 /* Inspector.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84BBB12B20142A4700F054F5 /* Inspector.storyboard */; };
+		65ED406E235DEF6C0081F399 /* AddFeedSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363002262A3BC00DA1D35 /* AddFeedSheet.xib */; };
+		65ED4071235DEF6C0081F399 /* RSWeb.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4072235DEF6C0081F399 /* RSDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4073235DEF6C0081F399 /* RSTree.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4074235DEF6C0081F399 /* ArticlesDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407167F2262A61100344432 /* ArticlesDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4076235DEF6C0081F399 /* Account.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8407166A2262A60D00344432 /* Account.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4077235DEF6C0081F399 /* Articles.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 840716732262A60F00344432 /* Articles.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4078235DEF6C0081F399 /* RSParser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED4079235DEF6C0081F399 /* SyncDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 51554C01228B6EB50055115A /* SyncDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED407A235DEF6C0081F399 /* RSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8120DD8CF200CA8CF5 /* RSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65ED407C235DEF6C0081F399 /* Subscribe to Feed.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65ED4092235DEF770081F399 /* SafariExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73920CED60100F4AD34 /* SafariExtensionViewController.swift */; };
+		65ED4093235DEF770081F399 /* SafariExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */; };
+		65ED4096235DEF770081F399 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 6581C74120CED60100F4AD34 /* ToolbarItemIcon.pdf */; };
+		65ED4097235DEF770081F399 /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6581C73B20CED60100F4AD34 /* SafariExtensionViewController.xib */; };
+		65ED4098235DEF770081F399 /* netnewswire-subscribe-to-feed.js in Resources */ = {isa = PBXBuildFile; fileRef = 6581C73F20CED60100F4AD34 /* netnewswire-subscribe-to-feed.js */; };
+		65ED40A0235DEFF00081F399 /* container-migration.plist in Resources */ = {isa = PBXBuildFile; fileRef = 65ED409F235DEFF00081F399 /* container-migration.plist */; };
+		65ED40A1235DEFF00081F399 /* container-migration.plist in Resources */ = {isa = PBXBuildFile; fileRef = 65ED409F235DEFF00081F399 /* container-migration.plist */; };
+		65ED42D9235E740D0081F399 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65ED42B0235E71B40081F399 /* Sparkle.framework */; };
+		65ED42DA235E74230081F399 /* org.sparkle-project.Downloader.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 65ED42BC235E71B40081F399 /* org.sparkle-project.Downloader.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65ED42DB235E74230081F399 /* org.sparkle-project.InstallerConnection.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 65ED42B8235E71B40081F399 /* org.sparkle-project.InstallerConnection.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65ED42DC235E74230081F399 /* org.sparkle-project.InstallerLauncher.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 65ED42B6235E71B40081F399 /* org.sparkle-project.InstallerLauncher.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65ED42DD235E74230081F399 /* org.sparkle-project.InstallerStatus.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 65ED42BA235E71B40081F399 /* org.sparkle-project.InstallerStatus.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65ED42DE235E74230081F399 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65ED42B0235E71B40081F399 /* Sparkle.framework */; };
+		65ED42DF235E74230081F399 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 65ED42B0235E71B40081F399 /* Sparkle.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		8405DD8A2213E0E3008CE1BF /* DetailContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD892213E0E3008CE1BF /* DetailContainerView.swift */; };
+		8405DD9922153B6B008CE1BF /* TimelineContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD9822153B6B008CE1BF /* TimelineContainerView.swift */; };
+		8405DD9C22153BD7008CE1BF /* NSView-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DD9B22153BD7008CE1BF /* NSView-Extensions.swift */; };
+		8405DDA222168920008CE1BF /* TimelineTableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8405DDA122168920008CE1BF /* TimelineTableView.xib */; };
+		8405DDA522168C62008CE1BF /* TimelineContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8405DDA422168C62008CE1BF /* TimelineContainerViewController.swift */; };
+		840958632201629A002C1579 /* Subscribe to Feed.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		840BEE4121D70E64009BBAFA /* CrashReportWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840BEE4021D70E64009BBAFA /* CrashReportWindowController.swift */; };
+		840D617F2029031C009BC708 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840D617E2029031C009BC708 /* AppDelegate.swift */; };
+		84162A152038C12C00035290 /* MarkCommandValidationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84162A142038C12C00035290 /* MarkCommandValidationStatus.swift */; };
+		841ABA4E20145E7300980E11 /* NothingInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA4D20145E7300980E11 /* NothingInspectorViewController.swift */; };
+		841ABA5E20145E9200980E11 /* FolderInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA5D20145E9200980E11 /* FolderInspectorViewController.swift */; };
+		841ABA6020145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841ABA5F20145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift */; };
+		84216D0322128B9D0049B9B9 /* DetailWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84216D0222128B9D0049B9B9 /* DetailWebViewController.swift */; };
+		8426118A1FCB67AA0086A189 /* FeedIconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611891FCB67AA0086A189 /* FeedIconDownloader.swift */; };
+		8426119E1FCB6ED40086A189 /* HTMLMetadataDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426119D1FCB6ED40086A189 /* HTMLMetadataDownloader.swift */; };
+		842611A21FCB769D0086A189 /* RSHTMLMetadata+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842611A11FCB769D0086A189 /* RSHTMLMetadata+Extension.swift */; };
+		842E45CE1ED8C308000A8B52 /* AppNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E45CD1ED8C308000A8B52 /* AppNotifications.swift */; };
+		842E45DD1ED8C54B000A8B52 /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E45DC1ED8C54B000A8B52 /* Browser.swift */; };
+		84411E711FE5FBFA004B527F /* SmallIconProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84411E701FE5FBFA004B527F /* SmallIconProvider.swift */; };
+		8444C8F21FED81840051386C /* OPMLExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8444C8F11FED81840051386C /* OPMLExporter.swift */; };
+		844B5B591FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B581FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift */; };
+		844B5B5B1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B5A1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift */; };
+		844B5B651FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B641FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist */; };
+		844B5B671FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844B5B661FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift */; };
+		844B5B691FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 844B5B681FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist */; };
+		845213231FCA5B11003B6E93 /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845213221FCA5B10003B6E93 /* ImageDownloader.swift */; };
+		845479881FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist in Resources */ = {isa = PBXBuildFile; fileRef = 845479871FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist */; };
+		845A29091FC74B8E007B49E3 /* SingleFaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29081FC74B8E007B49E3 /* SingleFaviconDownloader.swift */; };
+		845A29221FC9251E007B49E3 /* SidebarCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29211FC9251E007B49E3 /* SidebarCellLayout.swift */; };
+		845A29241FC9255E007B49E3 /* SidebarCellAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845A29231FC9255E007B49E3 /* SidebarCellAppearance.swift */; };
+		845EE7B11FC2366500854A1F /* StarredFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */; };
+		845EE7C11FC2488C00854A1F /* SmartFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845EE7C01FC2488C00854A1F /* SmartFeed.swift */; };
+		84702AA41FA27AC0006B8943 /* MarkStatusCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84702AA31FA27AC0006B8943 /* MarkStatusCommand.swift */; };
+		8472058120142E8900AD578B /* FeedInspectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8472058020142E8900AD578B /* FeedInspectorViewController.swift */; };
+		8477ACBE22238E9500DF7F37 /* SearchFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */; };
+		847CD6CA232F4CBF00FAC46D /* TimelineAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847CD6C9232F4CBF00FAC46D /* TimelineAvatarView.swift */; };
+		847E64A02262783000E00365 /* NSAppleEventDescriptor+UserRecordFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847E64942262782F00E00365 /* NSAppleEventDescriptor+UserRecordFields.swift */; };
+		848362FD2262A30800DA1D35 /* styleSheet.css in Resources */ = {isa = PBXBuildFile; fileRef = 848362FC2262A30800DA1D35 /* styleSheet.css */; };
+		848362FF2262A30E00DA1D35 /* template.html in Resources */ = {isa = PBXBuildFile; fileRef = 848362FE2262A30E00DA1D35 /* template.html */; };
+		848363022262A3BD00DA1D35 /* AddFeedSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363002262A3BC00DA1D35 /* AddFeedSheet.xib */; };
+		848363052262A3CC00DA1D35 /* AddFolderSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363032262A3CC00DA1D35 /* AddFolderSheet.xib */; };
+		848363082262A3DD00DA1D35 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 848363062262A3DD00DA1D35 /* Main.storyboard */; };
+		8483630B2262A3F000DA1D35 /* RenameSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 848363092262A3F000DA1D35 /* RenameSheet.xib */; };
+		8483630E2262A3FE00DA1D35 /* MainWindow.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8483630C2262A3FE00DA1D35 /* MainWindow.storyboard */; };
+		848B937221C8C5540038DC0D /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B937121C8C5540038DC0D /* CrashReporter.swift */; };
+		848D578E21543519005FFAD5 /* PasteboardFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848D578D21543519005FFAD5 /* PasteboardFeed.swift */; };
+		848F6AE51FC29CFB002D422E /* FaviconDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848F6AE41FC29CFA002D422E /* FaviconDownloader.swift */; };
+		849A97431ED9EAA9007D329B /* AddFolderWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97421ED9EAA9007D329B /* AddFolderWindowController.swift */; };
+		849A97531ED9EAC0007D329B /* AddFeedController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97511ED9EAC0007D329B /* AddFeedController.swift */; };
+		849A97541ED9EAC0007D329B /* AddFeedWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97521ED9EAC0007D329B /* AddFeedWindowController.swift */; };
+		849A975B1ED9EB0D007D329B /* ArticleUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97581ED9EB0D007D329B /* ArticleUtilities.swift */; };
+		849A975C1ED9EB0D007D329B /* DefaultFeedsImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97591ED9EB0D007D329B /* DefaultFeedsImporter.swift */; };
+		849A975E1ED9EB72007D329B /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A975D1ED9EB72007D329B /* MainWindowController.swift */; };
+		849A97641ED9EB96007D329B /* SidebarOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97601ED9EB96007D329B /* SidebarOutlineView.swift */; };
+		849A97651ED9EB96007D329B /* FeedTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97611ED9EB96007D329B /* FeedTreeControllerDelegate.swift */; };
+		849A97661ED9EB96007D329B /* SidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97621ED9EB96007D329B /* SidebarViewController.swift */; };
+		849A97671ED9EB96007D329B /* UnreadCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97631ED9EB96007D329B /* UnreadCountView.swift */; };
+		849A976C1ED9EBC8007D329B /* TimelineTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97691ED9EBC8007D329B /* TimelineTableRowView.swift */; };
+		849A976D1ED9EBC8007D329B /* TimelineTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A976A1ED9EBC8007D329B /* TimelineTableView.swift */; };
+		849A976E1ED9EBC8007D329B /* TimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A976B1ED9EBC8007D329B /* TimelineViewController.swift */; };
+		849A97761ED9EC04007D329B /* TimelineCellAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97701ED9EC04007D329B /* TimelineCellAppearance.swift */; };
+		849A97771ED9EC04007D329B /* TimelineCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97711ED9EC04007D329B /* TimelineCellData.swift */; };
+		849A97781ED9EC04007D329B /* TimelineCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97721ED9EC04007D329B /* TimelineCellLayout.swift */; };
+		849A97791ED9EC04007D329B /* ArticleStringFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97731ED9EC04007D329B /* ArticleStringFormatter.swift */; };
+		849A977A1ED9EC04007D329B /* TimelineTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97741ED9EC04007D329B /* TimelineTableCellView.swift */; };
+		849A977B1ED9EC04007D329B /* UnreadIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97751ED9EC04007D329B /* UnreadIndicatorView.swift */; };
+		849A977F1ED9EC42007D329B /* ArticleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A977D1ED9EC42007D329B /* ArticleRenderer.swift */; };
+		849A97801ED9EC42007D329B /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A977E1ED9EC42007D329B /* DetailViewController.swift */; };
+		849A97831ED9EC63007D329B /* SidebarStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97821ED9EC63007D329B /* SidebarStatusBarView.swift */; };
+		849A97891ED9ECEF007D329B /* ArticleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97871ED9ECEF007D329B /* ArticleStyle.swift */; };
+		849A978A1ED9ECEF007D329B /* ArticleStylesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97881ED9ECEF007D329B /* ArticleStylesManager.swift */; };
+		849A97981ED9EFAA007D329B /* Node-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97971ED9EFAA007D329B /* Node-Extensions.swift */; };
+		849A979F1ED9F130007D329B /* SidebarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A979E1ED9F130007D329B /* SidebarCell.swift */; };
+		849A97A31ED9F180007D329B /* FolderTreeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */; };
+		849ADEE42359817E000E1B81 /* NNW3ImportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849ADEE02359817D000E1B81 /* NNW3ImportController.swift */; };
+		849ADEE623598189000E1B81 /* NNW3OpenPanelAccessoryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 849ADEE523598189000E1B81 /* NNW3OpenPanelAccessoryView.xib */; };
+		849ADEE8235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849ADEE7235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift */; };
+		849C64681ED37A5D003D8FC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 849C64671ED37A5D003D8FC0 /* Assets.xcassets */; };
+		849C78902362AAFC009A71E4 /* ExportOPMLSheet.xib in Resources */ = {isa = PBXBuildFile; fileRef = 849C78872362AAFB009A71E4 /* ExportOPMLSheet.xib */; };
+		849C78922362AB04009A71E4 /* ExportOPMLWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849C78912362AB04009A71E4 /* ExportOPMLWindowController.swift */; };
+		849EE70F203919360082A1EA /* AppAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849EE70E203919360082A1EA /* AppAssets.swift */; };
+		849EE72120391F560082A1EA /* SharingServicePickerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849EE72020391F560082A1EA /* SharingServicePickerDelegate.swift */; };
+		84A14FF320048CA70046AD9A /* SendToMicroBlogCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A14FF220048CA70046AD9A /* SendToMicroBlogCommand.swift */; };
+		84A1500520048DDF0046AD9A /* SendToMarsEditCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1500420048DDF0046AD9A /* SendToMarsEditCommand.swift */; };
+		84A37CB5201ECD610087C5AF /* RenameWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A37CB4201ECD610087C5AF /* RenameWindowController.swift */; };
+		84A3EE5F223B667F00557320 /* DefaultFeeds.opml in Resources */ = {isa = PBXBuildFile; fileRef = 84A3EE52223B667F00557320 /* DefaultFeeds.opml */; };
+		84A3EE61223B667F00557320 /* DefaultFeeds.opml in Resources */ = {isa = PBXBuildFile; fileRef = 84A3EE52223B667F00557320 /* DefaultFeeds.opml */; };
+		84AD1EAA2031617300BC20B7 /* PasteboardFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EA92031617300BC20B7 /* PasteboardFolder.swift */; };
+		84AD1EBA2031649C00BC20B7 /* SmartFeedPasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EB92031649C00BC20B7 /* SmartFeedPasteboardWriter.swift */; };
+		84AD1EBC2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AD1EBB2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift */; };
+		84B7178C201E66580091657D /* SidebarViewController+ContextualMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B7178B201E66580091657D /* SidebarViewController+ContextualMenus.swift */; };
+		84B99C9D1FAE83C600ECDEDB /* DeleteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B99C9C1FAE83C600ECDEDB /* DeleteCommand.swift */; };
+		84BAE64921CEDAF20046DB56 /* CrashReporterWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84BAE64821CEDAF20046DB56 /* CrashReporterWindow.xib */; };
+		84BBB12D20142A4700F054F5 /* Inspector.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84BBB12B20142A4700F054F5 /* Inspector.storyboard */; };
+		84BBB12E20142A4700F054F5 /* InspectorWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BBB12C20142A4700F054F5 /* InspectorWindowController.swift */; };
+		84C37FA520DD8D8400CA8CF5 /* RSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8120DD8CF200CA8CF5 /* RSCore.framework */; };
+		84C37FA620DD8D8400CA8CF5 /* RSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8120DD8CF200CA8CF5 /* RSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84C37FA920DD8D9000CA8CF5 /* RSWeb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */; };
+		84C37FAA20DD8D9000CA8CF5 /* RSWeb.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84C37FAD20DD8D9900CA8CF5 /* RSTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; };
+		84C37FAE20DD8D9900CA8CF5 /* RSTree.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84C37FB520DD8DBB00CA8CF5 /* RSParser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; };
+		84C37FB620DD8DBB00CA8CF5 /* RSParser.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84C37FC520DD8E1D00CA8CF5 /* RSDatabase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */; };
+		84C37FC620DD8E1D00CA8CF5 /* RSDatabase.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84C9FC6722629B9000D921D6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6622629B3900D921D6 /* AppDelegate.swift */; };
+		84C9FC7722629E1200D921D6 /* AdvancedPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6B22629E1200D921D6 /* AdvancedPreferencesViewController.swift */; };
+		84C9FC7822629E1200D921D6 /* GeneralPrefencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6D22629E1200D921D6 /* GeneralPrefencesViewController.swift */; };
+		84C9FC7922629E1200D921D6 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC6E22629E1200D921D6 /* PreferencesWindowController.swift */; };
+		84C9FC7A22629E1200D921D6 /* AccountsTableViewBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7022629E1200D921D6 /* AccountsTableViewBackgroundView.swift */; };
+		84C9FC7B22629E1200D921D6 /* AccountsControlsBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7122629E1200D921D6 /* AccountsControlsBackgroundView.swift */; };
+		84C9FC7C22629E1200D921D6 /* AccountsPreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C9FC7222629E1200D921D6 /* AccountsPreferencesViewController.swift */; };
+		84C9FC7D22629E1200D921D6 /* AccountsDetail.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC7422629E1200D921D6 /* AccountsDetail.xib */; };
+		84C9FC8222629E4800D921D6 /* Preferences.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8022629E4800D921D6 /* Preferences.storyboard */; };
+		84C9FC8C22629E8F00D921D6 /* KeyboardShortcuts.html in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8722629E8F00D921D6 /* KeyboardShortcuts.html */; };
+		84C9FC8E22629E8F00D921D6 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8922629E8F00D921D6 /* Credits.rtf */; };
+		84C9FC8F22629E8F00D921D6 /* NetNewsWire.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC8A22629E8F00D921D6 /* NetNewsWire.sdef */; };
+		84C9FC9D2262A1A900D921D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC9B2262A1A900D921D6 /* Assets.xcassets */; };
+		84C9FCA12262A1B300D921D6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FC9F2262A1B300D921D6 /* Main.storyboard */; };
+		84C9FCA42262A1B800D921D6 /* LaunchScreenPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84C9FCA22262A1B800D921D6 /* LaunchScreenPhone.storyboard */; };
+		84CAFCA422BC8C08007694F0 /* FetchRequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCA322BC8C08007694F0 /* FetchRequestQueue.swift */; };
+		84CAFCA522BC8C08007694F0 /* FetchRequestQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCA322BC8C08007694F0 /* FetchRequestQueue.swift */; };
+		84CAFCAF22BC8C35007694F0 /* FetchRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCAE22BC8C35007694F0 /* FetchRequestOperation.swift */; };
+		84CAFCB022BC8C35007694F0 /* FetchRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CAFCAE22BC8C35007694F0 /* FetchRequestOperation.swift */; };
+		84CC88181FE59CBF00644329 /* SmartFeedsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CC88171FE59CBF00644329 /* SmartFeedsController.swift */; };
+		84D52E951FE588BB00D14F5B /* DetailStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D52E941FE588BB00D14F5B /* DetailStatusBarView.swift */; };
+		84DEE56522C32CA4005FC42C /* SmartFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */; };
+		84DEE56622C32CA4005FC42C /* SmartFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */; };
+		84E185B3203B74E500F69BFA /* SingleLineTextFieldSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E185B2203B74E500F69BFA /* SingleLineTextFieldSizer.swift */; };
+		84E185C3203BB12600F69BFA /* MultilineTextFieldSizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E185C2203BB12600F69BFA /* MultilineTextFieldSizer.swift */; };
+		84E46C7D1F75EF7B005ECFB3 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E46C7C1F75EF7B005ECFB3 /* AppDefaults.swift */; };
+		84E850861FCB60CE0072EA88 /* AuthorAvatarDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E850851FCB60CE0072EA88 /* AuthorAvatarDownloader.swift */; };
+		84E8E0DB202EC49300562D8F /* TimelineViewController+ContextualMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E8E0DA202EC49300562D8F /* TimelineViewController+ContextualMenus.swift */; };
+		84E8E0EB202F693600562D8F /* DetailWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E8E0EA202F693600562D8F /* DetailWebView.swift */; };
+		84E95D241FB1087500552D99 /* ArticlePasteboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E95D231FB1087500552D99 /* ArticlePasteboardWriter.swift */; };
+		84F204E01FAACBB30076E152 /* ArticleArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F204DF1FAACBB30076E152 /* ArticleArray.swift */; };
+		84F2D5371FC22FCC00998D64 /* PseudoFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5351FC22FCB00998D64 /* PseudoFeed.swift */; };
+		84F2D5381FC22FCC00998D64 /* TodayFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */; };
+		84F2D53A1FC2308B00998D64 /* UnreadFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2D5391FC2308B00998D64 /* UnreadFeed.swift */; };
+		84F9EAE5213660A100CF2DE4 /* AppleScriptXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD1213660A100CF2DE4 /* AppleScriptXCTestCase.swift */; };
+		84F9EAE6213660A100CF2DE4 /* ScriptingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD2213660A100CF2DE4 /* ScriptingTests.swift */; };
+		84F9EAE7213660A100CF2DE4 /* testNameOfAuthors.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD4213660A100CF2DE4 /* testNameOfAuthors.applescript */; };
+		84F9EAE8213660A100CF2DE4 /* testGetURL.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD5213660A100CF2DE4 /* testGetURL.applescript */; };
+		84F9EAE9213660A100CF2DE4 /* testNameAndUrlOfEveryFeed.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD6213660A100CF2DE4 /* testNameAndUrlOfEveryFeed.applescript */; };
+		84F9EAEA213660A100CF2DE4 /* testFeedExists.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD7213660A100CF2DE4 /* testFeedExists.applescript */; };
+		84F9EAEB213660A100CF2DE4 /* testIterativeCreateAndDeleteFeed.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD8213660A100CF2DE4 /* testIterativeCreateAndDeleteFeed.applescript */; };
+		84F9EAEC213660A100CF2DE4 /* selectAFeed.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAD9213660A100CF2DE4 /* selectAFeed.applescript */; };
+		84F9EAED213660A100CF2DE4 /* uiScriptingTestSetup.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADA213660A100CF2DE4 /* uiScriptingTestSetup.applescript */; };
+		84F9EAEF213660A100CF2DE4 /* testNameOfEveryFolder.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADC213660A100CF2DE4 /* testNameOfEveryFolder.applescript */; };
+		84F9EAF0213660A100CF2DE4 /* testFeedOPML.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADD213660A100CF2DE4 /* testFeedOPML.applescript */; };
+		84F9EAF1213660A100CF2DE4 /* selectAnArticle.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADE213660A100CF2DE4 /* selectAnArticle.applescript */; };
+		84F9EAF2213660A100CF2DE4 /* testTitleOfArticlesWhose.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EADF213660A100CF2DE4 /* testTitleOfArticlesWhose.applescript */; };
+		84F9EAF3213660A100CF2DE4 /* testCurrentArticleIsNil.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAE0213660A100CF2DE4 /* testCurrentArticleIsNil.applescript */; };
+		84F9EAF4213660A100CF2DE4 /* testGenericScript.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAE1213660A100CF2DE4 /* testGenericScript.applescript */; };
+		84F9EAF5213660A100CF2DE4 /* establishMainWindowStartingState.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 84F9EAE2213660A100CF2DE4 /* establishMainWindowStartingState.applescript */; };
+		84FF69B11FC3793300DC198E /* FaviconURLFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */; };
+		9EA33BB92318F8C10097B644 /* AccountsFeedlyWebWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA33BB72318F8C10097B644 /* AccountsFeedlyWebWindowController.swift */; };
+		9EA33BBA2318F8C10097B644 /* AccountsFeedlyWeb.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9EA33BB82318F8C10097B644 /* AccountsFeedlyWeb.xib */; };
+		B528F81E23333C7E00E735DD /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = B528F81D23333C7E00E735DD /* page.html */; };
+		D553738B20186C20006D8857 /* Article+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D553737C20186C1F006D8857 /* Article+Scriptability.swift */; };
+		D57BE6E0204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */; };
+		D5907D7F2004AC00005947E5 /* NSApplication+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907D7E2004AC00005947E5 /* NSApplication+Scriptability.swift */; };
+		D5907D972004B7EB005947E5 /* Account+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907D962004B7EB005947E5 /* Account+Scriptability.swift */; };
+		D5907DB22004BB37005947E5 /* ScriptingObjectContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907DB12004BB37005947E5 /* ScriptingObjectContainer.swift */; };
+		D5A2678C20130ECF00A8D3C0 /* Author+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A2678B20130ECF00A8D3C0 /* Author+Scriptability.swift */; };
+		D5E4CC54202C1361009B4FFC /* AppDelegate+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */; };
+		D5E4CC64202C1AC1009B4FFC /* MainWindowController+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */; };
+		D5F4EDB5200744A700B9E363 /* ScriptingObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */; };
+		D5F4EDB720074D6500B9E363 /* Feed+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */; };
+		D5F4EDB920074D7C00B9E363 /* Folder+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */; };
+		DD82AB0A231003F6002269DF /* SharingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD82AB09231003F6002269DF /* SharingTests.swift */; };
+		FF3ABF13232599810074C542 /* ArticleSorterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF09232599450074C542 /* ArticleSorterTests.swift */; };
+		FF3ABF1523259DDB0074C542 /* ArticleSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */; };
+		FF3ABF162325AF5D0074C542 /* ArticleSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */; };
+		FFD43E412340F488009E5CA3 /* UndoAvailableAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD43E372340F320009E5CA3 /* UndoAvailableAlertController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5131463C235A7BBE00387FDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 849C64581ED37A5D003D8FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 51314636235A7BBE00387FDC;
+			remoteInfo = "NetNewsWire iOS Intents Extension";
+		};
+		51554C00228B6EB50055115A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 51554BEB228B6E8F0055115A;
+			remoteInfo = SyncDatabase;
+		};
+		51554C26228B71910055115A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 51554BEA228B6E8F0055115A;
+			remoteInfo = SyncDatabase;
+		};
+		518B2ED72351B3DD00400001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 849C64581ED37A5D003D8FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 840D617B2029031C009BC708;
+			remoteInfo = "NetNewsWire-iOS";
+		};
+		51C451AB226377C300C03939 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 844BEE361F0AB3AA004AB7CD;
+			remoteInfo = ArticlesDatabase;
+		};
+		51C451BB226377C900C03939 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D542106B3D500DD04E6 /* Articles.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 844BEE5A1F0AB3C8004AB7CD;
+			remoteInfo = Articles;
+		};
+		51C451BF226377D000C03939 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 846E77301F6EF5D600A165E2 /* Account.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 848934F51F62484F00CEBD24;
+			remoteInfo = Account;
+		};
+		65ED3FA4235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84CFF4F31AC3C69700CEA6C8;
+			remoteInfo = RSCore;
+		};
+		65ED3FA6235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 849C08B51E0CAC85006B03FA;
+			remoteInfo = RSWeb;
+		};
+		65ED3FA8235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 842A0BE01CFCB9BC00BF746C;
+			remoteInfo = RSTree;
+		};
+		65ED3FAA235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84FF5F831EFA285800C15A01;
+			remoteInfo = RSParser;
+		};
+		65ED3FAC235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84F22C541B52E0D9000060CE;
+			remoteInfo = RSDatabase;
+		};
+		65ED3FAE235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 844BEE361F0AB3AA004AB7CD;
+			remoteInfo = ArticlesDatabase;
+		};
+		65ED3FB0235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D542106B3D500DD04E6 /* Articles.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 844BEE5A1F0AB3C8004AB7CD;
+			remoteInfo = Articles;
+		};
+		65ED3FB2235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 846E77301F6EF5D600A165E2 /* Account.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 848934F51F62484F00CEBD24;
+			remoteInfo = Account;
+		};
+		65ED3FB4235DEF6C0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 51554BEA228B6E8F0055115A;
+			remoteInfo = SyncDatabase;
+		};
+		65ED41C4235E61550081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 849C64581ED37A5D003D8FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6581C73220CED60000F4AD34;
+			remoteInfo = "Subscribe to Feed";
+		};
+		65ED41C6235E615E0081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 849C64581ED37A5D003D8FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65ED4090235DEF770081F399;
+			remoteInfo = "Subscribe to Feed MAS";
+		};
+		65ED42AF235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8DC2EF5B0486A6940098B216;
+			remoteInfo = Sparkle;
+		};
+		65ED42B1235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 72A5D59C1D6927730009E5AC;
+			remoteInfo = SparkleCore;
+		};
+		65ED42B3235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 72B398D21D3D879300EE297F;
+			remoteInfo = Autoupdate;
+		};
+		65ED42B5235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 726E07AD1CAF08D6001A286B;
+			remoteInfo = SparkleInstallerLauncher;
+		};
+		65ED42B7235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 724BB36C1D31D0B7005D534A;
+			remoteInfo = SparkleInstallerConnection;
+		};
+		65ED42B9235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 724BB3931D333832005D534A;
+			remoteInfo = SparkleInstallerStatus;
+		};
+		65ED42BB235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 726E07EF1CAF37BD001A286B;
+			remoteInfo = SparkleDownloader;
+		};
+		65ED42BD235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 61B5F90209C4CEE200B25A18;
+			remoteInfo = "Sparkle Test App";
+		};
+		65ED42BF235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 726E4A161C86C88F00C57C6A;
+			remoteInfo = TestAppHelper;
+		};
+		65ED42C1235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 612279D90DB5470200AB99EA;
+			remoteInfo = "Sparkle Unit Tests";
+		};
+		65ED42C3235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5D06E8D00FD68C7C005AE3F6;
+			remoteInfo = BinaryDelta;
+		};
+		65ED42C5235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 72D9549E1CBB415B006F28BD;
+			remoteInfo = "sparkle-cli";
+		};
+		65ED42C7235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 721C24451CB753E6005440CB;
+			remoteInfo = "Installer Progress";
+		};
+		65ED42C9235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 726B2B5D1C645FC900388755;
+			remoteInfo = "UI Tests";
+		};
+		65ED42CB235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7205C43E1E13049400E370AE;
+			remoteInfo = generate_appcast;
+		};
+		65ED42CD235E71B40081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EA1E280F22B64522004AA304;
+			remoteInfo = bsdiff;
+		};
+		65ED42CF235E71F60081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
+			remoteInfo = Sparkle;
+		};
+		65ED42D1235E72000081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 726E07EE1CAF37BD001A286B;
+			remoteInfo = SparkleDownloader;
+		};
+		65ED42D3235E72000081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 724BB36B1D31D0B7005D534A;
+			remoteInfo = SparkleInstallerConnection;
+		};
+		65ED42D5235E72000081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 726E07AC1CAF08D6001A286B;
+			remoteInfo = SparkleInstallerLauncher;
+		};
+		65ED42D7235E72000081F399 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 724BB3921D333832005D534A;
+			remoteInfo = SparkleInstallerStatus;
+		};
+		840716692262A60D00344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 846E77301F6EF5D600A165E2 /* Account.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 848934F61F62484F00CEBD24;
+			remoteInfo = Account;
+		};
+		8407166B2262A60D00344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 846E77301F6EF5D600A165E2 /* Account.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 848934FF1F62484F00CEBD24;
+			remoteInfo = AccountTests;
+		};
+		840716722262A60F00344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D542106B3D500DD04E6 /* Articles.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 844BEE5B1F0AB3C8004AB7CD;
+			remoteInfo = Articles;
+		};
+		840716742262A60F00344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D542106B3D500DD04E6 /* Articles.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 844BEE641F0AB3C9004AB7CD;
+			remoteInfo = ArticlesTests;
+		};
+		8407167E2262A61100344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 844BEE371F0AB3AA004AB7CD;
+			remoteInfo = ArticlesDatabase;
+		};
+		840716802262A61100344432 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 844BEE401F0AB3AB004AB7CD;
+			remoteInfo = ArticlesDatabaseTests;
+		};
+		849C64721ED37A5D003D8FC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 849C64581ED37A5D003D8FC0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 849C645F1ED37A5D003D8FC0;
+			remoteInfo = NetNewsWire;
+		};
+		84C37F8020DD8CF200CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84CFF4F41AC3C69700CEA6C8;
+			remoteInfo = RSCore;
+		};
+		84C37F8220DD8CF200CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84CFF4FF1AC3C69700CEA6C8;
+			remoteInfo = RSCoreTests;
+		};
+		84C37F8420DD8CF200CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 842DD7BC1E14993900E061EB;
+			remoteInfo = RSCoreiOS;
+		};
+		84C37F8B20DD8CF800CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84FF5F841EFA285800C15A01;
+			remoteInfo = RSParser;
+		};
+		84C37F8D20DD8CF800CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84FF5F8D1EFA285800C15A01;
+			remoteInfo = RSParserTests;
+		};
+		84C37F9420DD8CFE00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 842A0BE11CFCB9BC00BF746C;
+			remoteInfo = RSTree;
+		};
+		84C37F9620DD8CFE00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 842A0BEB1CFCB9BC00BF746C;
+			remoteInfo = RSTreeTests;
+		};
+		84C37F9E20DD8D0500CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 849C08B61E0CAC85006B03FA;
+			remoteInfo = RSWeb;
+		};
+		84C37FA020DD8D0500CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 849C08BF1E0CAC86006B03FA;
+			remoteInfo = RSWebTests;
+		};
+		84C37FA220DD8D0500CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 849C08D51E0CACA3006B03FA;
+			remoteInfo = RSWebiOS;
+		};
+		84C37FA720DD8D8400CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84CFF4F31AC3C69700CEA6C8;
+			remoteInfo = RSCore;
+		};
+		84C37FAB20DD8D9000CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 849C08B51E0CAC85006B03FA;
+			remoteInfo = RSWeb;
+		};
+		84C37FAF20DD8D9900CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 842A0BE01CFCB9BC00BF746C;
+			remoteInfo = RSTree;
+		};
+		84C37FB720DD8DBB00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84FF5F831EFA285800C15A01;
+			remoteInfo = RSParser;
+		};
+		84C37FBF20DD8E0C00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84F22C551B52E0D9000060CE;
+			remoteInfo = RSDatabase;
+		};
+		84C37FC120DD8E0C00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 84F22C5F1B52E0D9000060CE;
+			remoteInfo = RSDatabaseTests;
+		};
+		84C37FC320DD8E0C00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8400ABF71E0CFBD800AA7C57;
+			remoteInfo = RSDatabaseiOS;
+		};
+		84C37FC720DD8E1D00CA8CF5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84F22C541B52E0D9000060CE;
+			remoteInfo = RSDatabase;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		513C5CF1232571C2003D4054 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				513C5CF0232571C2003D4054 /* NetNewsWire iOS Share Extension.appex in Embed App Extensions */,
+				5131463E235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		51C451DF2264C7F200C03939 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				51C451D32264C7F200C03939 /* RSWeb.framework in Embed Frameworks */,
+				51C451E12264C7F900C03939 /* RSTree.framework in Embed Frameworks */,
+				51C451F92264C83E00C03939 /* Account.framework in Embed Frameworks */,
+				51C451F12264C83100C03939 /* ArticlesDatabase.framework in Embed Frameworks */,
+				51C451F52264C83900C03939 /* Articles.framework in Embed Frameworks */,
+				51C451E92264C81000C03939 /* RSDatabase.framework in Embed Frameworks */,
+				51554C31228B71A10055115A /* SyncDatabase.framework in Embed Frameworks */,
+				51C451ED2264C81B00C03939 /* RSCore.framework in Embed Frameworks */,
+				51C451E52264C80600C03939 /* RSParser.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6581C75720CED60100F4AD34 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				840958632201629A002C1579 /* Subscribe to Feed.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED4070235DEF6C0081F399 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				65ED4071235DEF6C0081F399 /* RSWeb.framework in Embed Frameworks */,
+				65ED4072235DEF6C0081F399 /* RSDatabase.framework in Embed Frameworks */,
+				65ED4073235DEF6C0081F399 /* RSTree.framework in Embed Frameworks */,
+				65ED4074235DEF6C0081F399 /* ArticlesDatabase.framework in Embed Frameworks */,
+				65ED4076235DEF6C0081F399 /* Account.framework in Embed Frameworks */,
+				65ED4077235DEF6C0081F399 /* Articles.framework in Embed Frameworks */,
+				65ED4078235DEF6C0081F399 /* RSParser.framework in Embed Frameworks */,
+				65ED4079235DEF6C0081F399 /* SyncDatabase.framework in Embed Frameworks */,
+				65ED407A235DEF6C0081F399 /* RSCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED407B235DEF6C0081F399 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				65ED407C235DEF6C0081F399 /* Subscribe to Feed.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED42E0235E74240081F399 /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				65ED42DD235E74230081F399 /* org.sparkle-project.InstallerStatus.xpc in Embed XPC Services */,
+				65ED42DB235E74230081F399 /* org.sparkle-project.InstallerConnection.xpc in Embed XPC Services */,
+				65ED42DC235E74230081F399 /* org.sparkle-project.InstallerLauncher.xpc in Embed XPC Services */,
+				65ED42DA235E74230081F399 /* org.sparkle-project.Downloader.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		84B06F681ED37B9000F0B54B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				84C37FAA20DD8D9000CA8CF5 /* RSWeb.framework in Embed Frameworks */,
+				84C37FC620DD8E1D00CA8CF5 /* RSDatabase.framework in Embed Frameworks */,
+				84C37FAE20DD8D9900CA8CF5 /* RSTree.framework in Embed Frameworks */,
+				51C451AA226377C200C03939 /* ArticlesDatabase.framework in Embed Frameworks */,
+				51C451BE226377D000C03939 /* Account.framework in Embed Frameworks */,
+				51C451BA226377C900C03939 /* Articles.framework in Embed Frameworks */,
+				84C37FB620DD8DBB00CA8CF5 /* RSParser.framework in Embed Frameworks */,
+				65ED42DF235E74230081F399 /* Sparkle.framework in Embed Frameworks */,
+				51554C25228B71910055115A /* SyncDatabase.framework in Embed Frameworks */,
+				84C37FA620DD8D8400CA8CF5 /* RSCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D5907C9B20022EC7005947E5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = TestScripts;
+			dstSubfolderSpec = 7;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		49F40DEF2335B71000552BF4 /* newsfoot.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = newsfoot.js; sourceTree = "<group>"; };
+		51102164233A7D6C0007A5F7 /* ArticleExtractorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleExtractorButton.swift; sourceTree = "<group>"; };
+		51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = NetNewsWire_iOSapp_target.xcconfig; sourceTree = "<group>"; };
+		51121B5A22661FEF00BC0EC1 /* AddContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddContainerViewController.swift; sourceTree = "<group>"; };
+		51126DA3225FDE2F00722696 /* RSImage-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSImage-Extensions.swift"; sourceTree = "<group>"; };
+		511D43EE231FBDE800FB1562 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreenPad.storyboard; sourceTree = "<group>"; };
+		511D4410231FC02D00FB1562 /* KeyboardManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardManager.swift; sourceTree = "<group>"; };
+		512363372369155100951F16 /* RoundedProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedProgressView.swift; sourceTree = "<group>"; };
+		5123DB9E233EC6FD00282CC9 /* FeedInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedInspectorView.swift; sourceTree = "<group>"; };
+		5126EE96226CB48A00C22AFC /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
+		5127B236222B4849006D641D /* DetailKeyboardDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailKeyboardDelegate.swift; sourceTree = "<group>"; };
+		5127B237222B4849006D641D /* DetailKeyboardShortcuts.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = DetailKeyboardShortcuts.plist; sourceTree = "<group>"; };
+		512E08F722688F7C00BDCFDD /* MasterFeedTableViewSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterFeedTableViewSectionHeader.swift; sourceTree = "<group>"; };
+		512E092B2268B25500BDCFDD /* UISplitViewController-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISplitViewController-Extensions.swift"; sourceTree = "<group>"; };
+		51314617235A797400387FDC /* NetNewsWire_iOSintentextension_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_iOSintentextension_target.xcconfig; sourceTree = "<group>"; };
+		51314637235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "NetNewsWire iOS Intents Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		51314665235A7E4600387FDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		51314666235A7E4600387FDC /* IntentHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntentHandler.swift; sourceTree = "<group>"; };
+		51314684235A7EB900387FDC /* NetNewsWire_iOS_IntentsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetNewsWire_iOS_IntentsExtension.entitlements; sourceTree = "<group>"; };
+		513146B1235A81A400387FDC /* AddFeedIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFeedIntentHandler.swift; sourceTree = "<group>"; };
+		51314706235C41FC00387FDC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; name = Base; path = Base.lproj/Intents.intentdefinition; sourceTree = "<group>"; };
+		51314714235C420900387FDC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Intents.strings; sourceTree = "<group>"; };
+		513228F2233037620033D4ED /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		513C5CE6232571C2003D4054 /* NetNewsWire iOS Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "NetNewsWire iOS Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		513C5CE8232571C2003D4054 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		513C5CEB232571C2003D4054 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		513C5CED232571C2003D4054 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5142192923522B5500E07E2C /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
+		514219362352510100E07E2C /* ImageScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageScrollView.swift; sourceTree = "<group>"; };
+		5142194A2353C1CF00E07E2C /* main_mac.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = main_mac.js; sourceTree = "<group>"; };
+		514219572353C28900E07E2C /* main_ios.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = main_ios.js; sourceTree = "<group>"; };
+		5144EA2E2279FAB600D19003 /* AccountsDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsDetailViewController.swift; sourceTree = "<group>"; };
+		5144EA352279FC3D00D19003 /* AccountsAddLocal.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccountsAddLocal.xib; sourceTree = "<group>"; };
+		5144EA372279FC6200D19003 /* AccountsAddLocalWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsAddLocalWindowController.swift; sourceTree = "<group>"; };
+		5144EA3A227A379E00D19003 /* ImportOPMLSheet.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImportOPMLSheet.xib; sourceTree = "<group>"; };
+		5144EA3E227A37EC00D19003 /* ImportOPMLWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportOPMLWindowController.swift; sourceTree = "<group>"; };
+		5144EA4F227B8E4500D19003 /* AccountsFeedbinWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsFeedbinWindowController.swift; sourceTree = "<group>"; };
+		5144EA50227B8E4500D19003 /* AccountsFeedbin.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccountsFeedbin.xib; sourceTree = "<group>"; };
+		5148F44A2336DB4700F8CD8B /* MasterTimelineTitleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MasterTimelineTitleView.xib; sourceTree = "<group>"; };
+		5148F4542336DB7000F8CD8B /* MasterTimelineTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTimelineTitleView.swift; sourceTree = "<group>"; };
+		514B7C8223205EFB00BAC947 /* RootSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootSplitViewController.swift; sourceTree = "<group>"; };
+		514B7D1E23219F3C00BAC947 /* AddControllerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddControllerType.swift; sourceTree = "<group>"; };
+		51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SyncDatabase.xcodeproj; path = Frameworks/SyncDatabase/SyncDatabase.xcodeproj; sourceTree = SOURCE_ROOT; };
+		515D4FCB2325815A00EE1167 /* SafariExt.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = SafariExt.js; sourceTree = "<group>"; };
+		515D4FCD2325909200EE1167 /* NetNewsWire_iOS_ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetNewsWire_iOS_ShareExtension.entitlements; sourceTree = "<group>"; };
+		515D4FCE2325B3D000EE1167 /* NetNewsWire_iOSshareextension_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_iOSshareextension_target.xcconfig; sourceTree = "<group>"; };
+		516A091D23609A3600EAE89B /* SettingsAccountTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SettingsAccountTableViewCell.xib; sourceTree = "<group>"; };
+		516A09382360A2AE00EAE89B /* SettingsAccountTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountTableViewCell.swift; sourceTree = "<group>"; };
+		516A093A2360A4A000EAE89B /* SettingsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SettingsTableViewCell.xib; sourceTree = "<group>"; };
+		516A093F2361240900EAE89B /* Account.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Account.storyboard; sourceTree = "<group>"; };
+		516A09412361248000EAE89B /* Inspector.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Inspector.storyboard; sourceTree = "<group>"; };
+		51707438232AA97100A461A3 /* ShareFolderPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFolderPickerController.swift; sourceTree = "<group>"; };
+		517630032336215100E15FFF /* main.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = main.js; sourceTree = "<group>"; };
+		517630222336657E00E15FFF /* ArticleViewControllerWebViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleViewControllerWebViewProvider.swift; sourceTree = "<group>"; };
+		5183CCCF226E1E880010922C /* NonIntrinsicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonIntrinsicLabel.swift; sourceTree = "<group>"; };
+		5183CCD9226E31A50010922C /* NonIntrinsicImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonIntrinsicImageView.swift; sourceTree = "<group>"; };
+		5183CCE4226F4DFA0010922C /* RefreshInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshInterval.swift; sourceTree = "<group>"; };
+		5183CCE7226F68D90010922C /* AccountRefreshTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRefreshTimer.swift; sourceTree = "<group>"; };
+		518651AB23555EB20078E021 /* NNW3Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NNW3Document.swift; sourceTree = "<group>"; };
+		518651D9235621840078E021 /* ImageTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTransition.swift; sourceTree = "<group>"; };
+		5186A634235EF3A800C97195 /* VibrantLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrantLabel.swift; sourceTree = "<group>"; };
+		518B2ED22351B3DD00400001 /* NetNewsWire-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "NetNewsWire-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		518B2EE92351B4C200400001 /* NetNewsWire_iOSTests_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_iOSTests_target.xcconfig; sourceTree = "<group>"; };
+		51934CC1230F5963006127BE /* ThemedNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedNavigationController.swift; sourceTree = "<group>"; };
+		51934CCD2310792F006127BE /* ActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityManager.swift; sourceTree = "<group>"; };
+		51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTimelineFeedDelegate.swift; sourceTree = "<group>"; };
+		519B8D322143397200FA689C /* SharingServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingServiceDelegate.swift; sourceTree = "<group>"; };
+		519D740523243CC0008BB345 /* RefreshInterval-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RefreshInterval-Extensions.swift"; sourceTree = "<group>"; };
+		519E743422C663F900A78E47 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		51A1698D235E10D600EB091F /* RefreshIntervalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefreshIntervalViewController.swift; sourceTree = "<group>"; };
+		51A1698F235E10D600EB091F /* LocalAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalAccountViewController.swift; sourceTree = "<group>"; };
+		51A16990235E10D600EB091F /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
+		51A16991235E10D600EB091F /* AccountInspectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountInspectorViewController.swift; sourceTree = "<group>"; };
+		51A16992235E10D600EB091F /* AddAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddAccountViewController.swift; sourceTree = "<group>"; };
+		51A16993235E10D600EB091F /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		51A16995235E10D600EB091F /* AboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
+		51A16996235E10D700EB091F /* FeedbinAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbinAccountViewController.swift; sourceTree = "<group>"; };
+		51AF460D232488C6001742EF /* Account-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account-Extensions.swift"; sourceTree = "<group>"; };
+		51B62E67233186730085F949 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
+		51BB7C262335A8E5008E8144 /* ArticleActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleActivityItemSource.swift; sourceTree = "<group>"; };
+		51BB7C302335ACDE008E8144 /* page.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = page.html; sourceTree = "<group>"; };
+		51C4524E226506F400C03939 /* UIStoryboard-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboard-Extensions.swift"; sourceTree = "<group>"; };
+		51C45250226506F400C03939 /* String-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String-Extensions.swift"; sourceTree = "<group>"; };
+		51C45254226507D200C03939 /* AppAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppAssets.swift; sourceTree = "<group>"; };
+		51C45255226507D200C03939 /* AppDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
+		51C45261226508F600C03939 /* MasterFeedUnreadCountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterFeedUnreadCountView.swift; sourceTree = "<group>"; };
+		51C45262226508F600C03939 /* MasterFeedTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterFeedTableViewCell.swift; sourceTree = "<group>"; };
+		51C45263226508F600C03939 /* MasterFeedTableViewCellLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterFeedTableViewCellLayout.swift; sourceTree = "<group>"; };
+		51C45264226508F600C03939 /* MasterFeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterFeedViewController.swift; sourceTree = "<group>"; };
+		51C4526E2265091600C03939 /* MasterTimelineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterTimelineViewController.swift; sourceTree = "<group>"; };
+		51C452702265091600C03939 /* MultilineUILabelSizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultilineUILabelSizer.swift; sourceTree = "<group>"; };
+		51C452712265091600C03939 /* MasterTimelineCellData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterTimelineCellData.swift; sourceTree = "<group>"; };
+		51C452722265091600C03939 /* MasterTimelineTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterTimelineTableViewCell.swift; sourceTree = "<group>"; };
+		51C452742265091600C03939 /* MasterUnreadIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterUnreadIndicatorView.swift; sourceTree = "<group>"; };
+		51C452752265091600C03939 /* MasterTimelineDefaultCellLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterTimelineDefaultCellLayout.swift; sourceTree = "<group>"; };
+		51C4527E2265092C00C03939 /* ArticleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleViewController.swift; sourceTree = "<group>"; };
+		51C452812265093600C03939 /* FlattenedAccountFolderPickerData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlattenedAccountFolderPickerData.swift; sourceTree = "<group>"; };
+		51C452822265093600C03939 /* Add.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Add.storyboard; sourceTree = "<group>"; };
+		51C452842265093600C03939 /* AddFeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddFeedViewController.swift; sourceTree = "<group>"; };
+		51C4528B2265095F00C03939 /* AddFolderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddFolderViewController.swift; sourceTree = "<group>"; };
+		51C452B32265141B00C03939 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/WebKit.framework; sourceTree = DEVELOPER_DIR; };
+		51C452B72265178500C03939 /* styleSheet.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = styleSheet.css; sourceTree = "<group>"; };
+		51CC9B3D231720B2000E842F /* MasterFeedDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterFeedDataSource.swift; sourceTree = "<group>"; };
+		51CE1C0823621EDA005548FC /* RefreshProgressView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefreshProgressView.xib; sourceTree = "<group>"; };
+		51CE1C0A23622006005548FC /* RefreshProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshProgressView.swift; sourceTree = "<group>"; };
+		51D6A5BB23199C85001C27D8 /* MasterTimelineDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTimelineDataSource.swift; sourceTree = "<group>"; };
+		51D87EE02311D34700E63F03 /* ActivityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityType.swift; sourceTree = "<group>"; };
+		51E3EB32229AB02C00645299 /* ErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
+		51E3EB3C229AB08300645299 /* ErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
+		51E595A4228CC36500FCC42B /* ArticleStatusSyncTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleStatusSyncTimer.swift; sourceTree = "<group>"; };
+		51EAED95231363EF00A9EEE3 /* NonIntrinsicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonIntrinsicButton.swift; sourceTree = "<group>"; };
+		51EC114B2149FE3300B296E3 /* FolderTreeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FolderTreeMenu.swift; path = AddFeed/FolderTreeMenu.swift; sourceTree = "<group>"; };
+		51EC892923511D3B0061B6F6 /* NetNewsWire_project_test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_project_test.xcconfig; sourceTree = "<group>"; };
+		51EF0F76227716200050506E /* FaviconGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconGenerator.swift; sourceTree = "<group>"; };
+		51EF0F78227716380050506E /* ColorHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorHash.swift; sourceTree = "<group>"; };
+		51EF0F7D2277A57D0050506E /* MasterTimelineAccessibilityCellLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTimelineAccessibilityCellLayout.swift; sourceTree = "<group>"; };
+		51EF0F7F2277A8330050506E /* MasterTimelineCellLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTimelineCellLayout.swift; sourceTree = "<group>"; };
+		51EF0F8D2279C9260050506E /* AccountsAdd.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccountsAdd.xib; sourceTree = "<group>"; };
+		51EF0F8F2279C9500050506E /* AccountsAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsAddViewController.swift; sourceTree = "<group>"; };
+		51EF0F912279CA620050506E /* AccountsAddTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsAddTableCellView.swift; sourceTree = "<group>"; };
+		51F85BEA22724CB600C787DC /* About.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = About.rtf; sourceTree = "<group>"; };
+		51F85BEC227251DF00C787DC /* Acknowledgments.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Acknowledgments.rtf; sourceTree = "<group>"; };
+		51F85BEE2272520B00C787DC /* Thanks.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Thanks.rtf; sourceTree = "<group>"; };
+		51F85BF02272524100C787DC /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
+		51F85BF22272531500C787DC /* Dedication.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Dedication.rtf; sourceTree = "<group>"; };
+		51F85BF42273625800C787DC /* Bundle-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle-Extensions.swift"; sourceTree = "<group>"; };
+		51F85BF622749FA100C787DC /* UIFont-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont-Extensions.swift"; sourceTree = "<group>"; };
+		51F85BF82274AA7B00C787DC /* UIBarButtonItem-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem-Extensions.swift"; sourceTree = "<group>"; };
+		51F85BFA2275D85000C787DC /* Array-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array-Extensions.swift"; sourceTree = "<group>"; };
+		51F85BFC2275DCA800C787DC /* SingleLineUILabelSizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleLineUILabelSizer.swift; sourceTree = "<group>"; };
+		51FA73A32332BE110090D516 /* ArticleExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleExtractor.swift; sourceTree = "<group>"; };
+		51FA73A62332BE880090D516 /* ExtractedArticle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtractedArticle.swift; sourceTree = "<group>"; };
+		51FA73A92332C2FD0090D516 /* ArticleExtractorConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleExtractorConfig.swift; sourceTree = "<group>"; };
+		51FA73B62332D5F70090D516 /* ArticleExtractorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleExtractorButton.swift; sourceTree = "<group>"; };
+		51FD40BD2341555600880194 /* UIImage-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage-Extensions.swift"; sourceTree = "<group>"; };
+		51FD413A2342BD0500880194 /* MasterTimelineUnreadCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterTimelineUnreadCountView.swift; sourceTree = "<group>"; };
+		51FE10022345529D0056195D /* UserNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationManager.swift; sourceTree = "<group>"; };
+		51FFF0C3235EE8E5002762AA /* VibrantButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrantButton.swift; sourceTree = "<group>"; };
+		55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountsReaderAPI.xib; sourceTree = "<group>"; };
+		55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsReaderAPIWindowController.swift; sourceTree = "<group>"; };
+		5F323808231DF9F000706F6B /* VibrantTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrantTableViewCell.swift; sourceTree = "<group>"; };
+		6543108B2322D90900658221 /* common */ = {isa = PBXFileReference; lastKnownFileType = folder; path = common; sourceTree = "<group>"; };
+		6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Subscribe to Feed.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6581C73420CED60100F4AD34 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionHandler.swift; sourceTree = "<group>"; };
+		6581C73920CED60100F4AD34 /* SafariExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariExtensionViewController.swift; sourceTree = "<group>"; };
+		6581C73C20CED60100F4AD34 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/SafariExtensionViewController.xib; sourceTree = "<group>"; };
+		6581C73E20CED60100F4AD34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6581C73F20CED60100F4AD34 /* netnewswire-subscribe-to-feed.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "netnewswire-subscribe-to-feed.js"; sourceTree = "<group>"; };
+		6581C74120CED60100F4AD34 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
+		6581C74320CED60100F4AD34 /* Subscribe_to_Feed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Subscribe_to_Feed.entitlements; sourceTree = "<group>"; };
+		65ED4083235DEF6C0081F399 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetNewsWire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		65ED409D235DEF770081F399 /* Subscribe to Feed.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Subscribe to Feed.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		65ED409F235DEFF00081F399 /* container-migration.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "container-migration.plist"; sourceTree = "<group>"; };
+		65ED40F2235DF5E00081F399 /* NetNewsWire_macapp_target_macappstore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_macapp_target_macappstore.xcconfig; sourceTree = "<group>"; };
+		65ED4186235E045B0081F399 /* NetNewsWire_safariextension_target_macappstore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_safariextension_target_macappstore.xcconfig; sourceTree = "<group>"; };
+		65ED4299235E71B40081F399 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = submodules/Sparkle/Sparkle.xcodeproj; sourceTree = SOURCE_ROOT; };
+		8405DD892213E0E3008CE1BF /* DetailContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailContainerView.swift; sourceTree = "<group>"; };
+		8405DD9822153B6B008CE1BF /* TimelineContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineContainerView.swift; sourceTree = "<group>"; };
+		8405DD9B22153BD7008CE1BF /* NSView-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView-Extensions.swift"; sourceTree = "<group>"; };
+		8405DDA122168920008CE1BF /* TimelineTableView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimelineTableView.xib; sourceTree = "<group>"; };
+		8405DDA422168C62008CE1BF /* TimelineContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineContainerViewController.swift; sourceTree = "<group>"; };
+		840BEE4021D70E64009BBAFA /* CrashReportWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportWindowController.swift; sourceTree = "<group>"; };
+		840D617C2029031C009BC708 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetNewsWire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		840D617E2029031C009BC708 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		840D61952029031D009BC708 /* NetNewsWire_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetNewsWire_iOSTests.swift; sourceTree = "<group>"; };
+		840D61972029031D009BC708 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84162A142038C12C00035290 /* MarkCommandValidationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkCommandValidationStatus.swift; sourceTree = "<group>"; };
+		841ABA4D20145E7300980E11 /* NothingInspectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NothingInspectorViewController.swift; sourceTree = "<group>"; };
+		841ABA5D20145E9200980E11 /* FolderInspectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderInspectorViewController.swift; sourceTree = "<group>"; };
+		841ABA5F20145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltinSmartFeedInspectorViewController.swift; sourceTree = "<group>"; };
+		841D4D542106B3D500DD04E6 /* Articles.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Articles.xcodeproj; path = ../Frameworks/Articles/Articles.xcodeproj; sourceTree = "<group>"; };
+		841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ArticlesDatabase.xcodeproj; path = ../Frameworks/ArticlesDatabase/ArticlesDatabase.xcodeproj; sourceTree = "<group>"; };
+		84216D0222128B9D0049B9B9 /* DetailWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWebViewController.swift; sourceTree = "<group>"; };
+		842611891FCB67AA0086A189 /* FeedIconDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedIconDownloader.swift; sourceTree = "<group>"; };
+		8426119D1FCB6ED40086A189 /* HTMLMetadataDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLMetadataDownloader.swift; sourceTree = "<group>"; };
+		8426119F1FCB72600086A189 /* FeaturedImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedImageDownloader.swift; sourceTree = "<group>"; };
+		842611A11FCB769D0086A189 /* RSHTMLMetadata+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSHTMLMetadata+Extension.swift"; sourceTree = "<group>"; };
+		842E45CD1ED8C308000A8B52 /* AppNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppNotifications.swift; sourceTree = "<group>"; };
+		842E45DC1ED8C54B000A8B52 /* Browser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Browser.swift; sourceTree = "<group>"; };
+		84411E701FE5FBFA004B527F /* SmallIconProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallIconProvider.swift; sourceTree = "<group>"; };
+		8444C8F11FED81840051386C /* OPMLExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPMLExporter.swift; sourceTree = "<group>"; };
+		844B5B581FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarKeyboardDelegate.swift; sourceTree = "<group>"; };
+		844B5B5A1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineKeyboardDelegate.swift; sourceTree = "<group>"; };
+		844B5B641FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = GlobalKeyboardShortcuts.plist; sourceTree = "<group>"; };
+		844B5B661FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWIndowKeyboardHandler.swift; sourceTree = "<group>"; };
+		844B5B681FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = SidebarKeyboardShortcuts.plist; sourceTree = "<group>"; };
+		845213221FCA5B10003B6E93 /* ImageDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
+		845479871FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TimelineKeyboardShortcuts.plist; sourceTree = "<group>"; };
+		845A29081FC74B8E007B49E3 /* SingleFaviconDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleFaviconDownloader.swift; sourceTree = "<group>"; };
+		845A29211FC9251E007B49E3 /* SidebarCellLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarCellLayout.swift; sourceTree = "<group>"; };
+		845A29231FC9255E007B49E3 /* SidebarCellAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarCellAppearance.swift; sourceTree = "<group>"; };
+		845B14A51FC2299E0013CF92 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarredFeedDelegate.swift; sourceTree = "<group>"; };
+		845EE7C01FC2488C00854A1F /* SmartFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartFeed.swift; sourceTree = "<group>"; };
+		846E77301F6EF5D600A165E2 /* Account.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Account.xcodeproj; path = ../Frameworks/Account/Account.xcodeproj; sourceTree = "<group>"; };
+		84702AA31FA27AC0006B8943 /* MarkStatusCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkStatusCommand.swift; sourceTree = "<group>"; };
+		8472058020142E8900AD578B /* FeedInspectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedInspectorViewController.swift; sourceTree = "<group>"; };
+		847752FE2008879500D93690 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFeedDelegate.swift; sourceTree = "<group>"; };
+		847CD6C9232F4CBF00FAC46D /* TimelineAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineAvatarView.swift; sourceTree = "<group>"; };
+		847E64942262782F00E00365 /* NSAppleEventDescriptor+UserRecordFields.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAppleEventDescriptor+UserRecordFields.swift"; sourceTree = "<group>"; };
+		848362FC2262A30800DA1D35 /* styleSheet.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = styleSheet.css; sourceTree = "<group>"; };
+		848362FE2262A30E00DA1D35 /* template.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = template.html; sourceTree = "<group>"; };
+		848363012262A3BC00DA1D35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Mac/Base.lproj/AddFeedSheet.xib; sourceTree = SOURCE_ROOT; };
+		848363042262A3CC00DA1D35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Mac/Base.lproj/AddFolderSheet.xib; sourceTree = SOURCE_ROOT; };
+		848363072262A3DD00DA1D35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		8483630A2262A3F000DA1D35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Mac/Base.lproj/RenameSheet.xib; sourceTree = SOURCE_ROOT; };
+		8483630D2262A3FE00DA1D35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Mac/Base.lproj/MainWindow.storyboard; sourceTree = SOURCE_ROOT; };
+		848B937121C8C5540038DC0D /* CrashReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
+		848D578D21543519005FFAD5 /* PasteboardFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardFeed.swift; sourceTree = "<group>"; };
+		848F6AE41FC29CFA002D422E /* FaviconDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaviconDownloader.swift; sourceTree = "<group>"; };
+		849A97421ED9EAA9007D329B /* AddFolderWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddFolderWindowController.swift; sourceTree = "<group>"; };
+		849A97511ED9EAC0007D329B /* AddFeedController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AddFeedController.swift; path = AddFeed/AddFeedController.swift; sourceTree = "<group>"; };
+		849A97521ED9EAC0007D329B /* AddFeedWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AddFeedWindowController.swift; path = AddFeed/AddFeedWindowController.swift; sourceTree = "<group>"; };
+		849A97581ED9EB0D007D329B /* ArticleUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleUtilities.swift; sourceTree = "<group>"; };
+		849A97591ED9EB0D007D329B /* DefaultFeedsImporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFeedsImporter.swift; sourceTree = "<group>"; };
+		849A975D1ED9EB72007D329B /* MainWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
+		849A97601ED9EB96007D329B /* SidebarOutlineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarOutlineView.swift; sourceTree = "<group>"; };
+		849A97611ED9EB96007D329B /* FeedTreeControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedTreeControllerDelegate.swift; sourceTree = "<group>"; };
+		849A97621ED9EB96007D329B /* SidebarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarViewController.swift; sourceTree = "<group>"; };
+		849A97631ED9EB96007D329B /* UnreadCountView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnreadCountView.swift; sourceTree = "<group>"; };
+		849A97691ED9EBC8007D329B /* TimelineTableRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineTableRowView.swift; sourceTree = "<group>"; };
+		849A976A1ED9EBC8007D329B /* TimelineTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineTableView.swift; sourceTree = "<group>"; };
+		849A976B1ED9EBC8007D329B /* TimelineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineViewController.swift; sourceTree = "<group>"; };
+		849A97701ED9EC04007D329B /* TimelineCellAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineCellAppearance.swift; sourceTree = "<group>"; };
+		849A97711ED9EC04007D329B /* TimelineCellData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineCellData.swift; sourceTree = "<group>"; };
+		849A97721ED9EC04007D329B /* TimelineCellLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineCellLayout.swift; sourceTree = "<group>"; };
+		849A97731ED9EC04007D329B /* ArticleStringFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleStringFormatter.swift; sourceTree = "<group>"; };
+		849A97741ED9EC04007D329B /* TimelineTableCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelineTableCellView.swift; sourceTree = "<group>"; };
+		849A97751ED9EC04007D329B /* UnreadIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnreadIndicatorView.swift; sourceTree = "<group>"; };
+		849A977D1ED9EC42007D329B /* ArticleRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleRenderer.swift; sourceTree = "<group>"; };
+		849A977E1ED9EC42007D329B /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		849A97821ED9EC63007D329B /* SidebarStatusBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarStatusBarView.swift; sourceTree = "<group>"; };
+		849A97871ED9ECEF007D329B /* ArticleStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleStyle.swift; sourceTree = "<group>"; };
+		849A97881ED9ECEF007D329B /* ArticleStylesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleStylesManager.swift; sourceTree = "<group>"; };
+		849A97971ED9EFAA007D329B /* Node-Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Node-Extensions.swift"; sourceTree = "<group>"; };
+		849A979E1ED9F130007D329B /* SidebarCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarCell.swift; sourceTree = "<group>"; };
+		849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FolderTreeControllerDelegate.swift; sourceTree = "<group>"; };
+		849ADEE02359817D000E1B81 /* NNW3ImportController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NNW3ImportController.swift; sourceTree = "<group>"; };
+		849ADEE523598189000E1B81 /* NNW3OpenPanelAccessoryView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NNW3OpenPanelAccessoryView.xib; sourceTree = "<group>"; };
+		849ADEE7235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NNW3OpenPanelAccessoryViewController.swift; sourceTree = "<group>"; };
+		849C64601ED37A5D003D8FC0 /* NetNewsWire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetNewsWire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		849C64671ED37A5D003D8FC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		849C64711ED37A5D003D8FC0 /* NetNewsWireTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetNewsWireTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		849C78872362AAFB009A71E4 /* ExportOPMLSheet.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ExportOPMLSheet.xib; sourceTree = "<group>"; };
+		849C78912362AB04009A71E4 /* ExportOPMLWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportOPMLWindowController.swift; sourceTree = "<group>"; };
+		849EE70E203919360082A1EA /* AppAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAssets.swift; sourceTree = "<group>"; };
+		849EE72020391F560082A1EA /* SharingServicePickerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingServicePickerDelegate.swift; sourceTree = "<group>"; };
+		84A14FF220048CA70046AD9A /* SendToMicroBlogCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendToMicroBlogCommand.swift; sourceTree = "<group>"; };
+		84A1500420048DDF0046AD9A /* SendToMarsEditCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendToMarsEditCommand.swift; sourceTree = "<group>"; };
+		84A37CB4201ECD610087C5AF /* RenameWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenameWindowController.swift; sourceTree = "<group>"; };
+		84A3EE52223B667F00557320 /* DefaultFeeds.opml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = DefaultFeeds.opml; sourceTree = "<group>"; };
+		84AD1EA92031617300BC20B7 /* PasteboardFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardFolder.swift; sourceTree = "<group>"; };
+		84AD1EB92031649C00BC20B7 /* SmartFeedPasteboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartFeedPasteboardWriter.swift; sourceTree = "<group>"; };
+		84AD1EBB2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOutlineDataSource.swift; sourceTree = "<group>"; };
+		84B7178B201E66580091657D /* SidebarViewController+ContextualMenus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SidebarViewController+ContextualMenus.swift"; sourceTree = "<group>"; };
+		84B99C9C1FAE83C600ECDEDB /* DeleteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCommand.swift; sourceTree = "<group>"; };
+		84BAE64821CEDAF20046DB56 /* CrashReporterWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CrashReporterWindow.xib; sourceTree = "<group>"; };
+		84BB0F812333426400DED65E /* NetNewsWire.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetNewsWire.entitlements; sourceTree = "<group>"; };
+		84BBB12B20142A4700F054F5 /* Inspector.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Inspector.storyboard; sourceTree = "<group>"; };
+		84BBB12C20142A4700F054F5 /* InspectorWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InspectorWindowController.swift; sourceTree = "<group>"; };
+		84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RSCore.xcodeproj; path = submodules/RSCore/RSCore.xcodeproj; sourceTree = "<group>"; };
+		84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RSParser.xcodeproj; path = submodules/RSParser/RSParser.xcodeproj; sourceTree = "<group>"; };
+		84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RSTree.xcodeproj; path = submodules/RSTree/RSTree.xcodeproj; sourceTree = "<group>"; };
+		84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RSWeb.xcodeproj; path = submodules/RSWeb/RSWeb.xcodeproj; sourceTree = "<group>"; };
+		84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RSDatabase.xcodeproj; path = submodules/RSDatabase/RSDatabase.xcodeproj; sourceTree = "<group>"; };
+		84C9FC6622629B3900D921D6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		84C9FC6B22629E1200D921D6 /* AdvancedPreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvancedPreferencesViewController.swift; sourceTree = "<group>"; };
+		84C9FC6D22629E1200D921D6 /* GeneralPrefencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralPrefencesViewController.swift; sourceTree = "<group>"; };
+		84C9FC6E22629E1200D921D6 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
+		84C9FC7022629E1200D921D6 /* AccountsTableViewBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsTableViewBackgroundView.swift; sourceTree = "<group>"; };
+		84C9FC7122629E1200D921D6 /* AccountsControlsBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsControlsBackgroundView.swift; sourceTree = "<group>"; };
+		84C9FC7222629E1200D921D6 /* AccountsPreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsPreferencesViewController.swift; sourceTree = "<group>"; };
+		84C9FC7422629E1200D921D6 /* AccountsDetail.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountsDetail.xib; sourceTree = "<group>"; };
+		84C9FC8122629E4800D921D6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Mac/Base.lproj/Preferences.storyboard; sourceTree = SOURCE_ROOT; };
+		84C9FC8722629E8F00D921D6 /* KeyboardShortcuts.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = KeyboardShortcuts.html; sourceTree = "<group>"; };
+		84C9FC8922629E8F00D921D6 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
+		84C9FC8A22629E8F00D921D6 /* NetNewsWire.sdef */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NetNewsWire.sdef; sourceTree = "<group>"; };
+		84C9FC9022629ECB00D921D6 /* NetNewsWire.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NetNewsWire.entitlements; sourceTree = "<group>"; };
+		84C9FC9122629F2200D921D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84C9FC9B2262A1A900D921D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		84C9FC9C2262A1A900D921D6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84C9FCA02262A1B300D921D6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		84C9FCA32262A1B800D921D6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreenPhone.storyboard; sourceTree = "<group>"; };
+		84CAFCA322BC8C08007694F0 /* FetchRequestQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRequestQueue.swift; sourceTree = "<group>"; };
+		84CAFCAE22BC8C35007694F0 /* FetchRequestOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRequestOperation.swift; sourceTree = "<group>"; };
+		84CBDDAE1FD3674C005A61AA /* Technotes */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Technotes; sourceTree = "<group>"; };
+		84CC88171FE59CBF00644329 /* SmartFeedsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartFeedsController.swift; sourceTree = "<group>"; };
+		84D2200922B0BC4B0019E085 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		84D52E941FE588BB00D14F5B /* DetailStatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStatusBarView.swift; sourceTree = "<group>"; };
+		84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartFeedDelegate.swift; sourceTree = "<group>"; };
+		84E185B2203B74E500F69BFA /* SingleLineTextFieldSizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleLineTextFieldSizer.swift; sourceTree = "<group>"; };
+		84E185C2203BB12600F69BFA /* MultilineTextFieldSizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextFieldSizer.swift; sourceTree = "<group>"; };
+		84E46C7C1F75EF7B005ECFB3 /* AppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
+		84E850851FCB60CE0072EA88 /* AuthorAvatarDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorAvatarDownloader.swift; sourceTree = "<group>"; };
+		84E8E0DA202EC49300562D8F /* TimelineViewController+ContextualMenus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimelineViewController+ContextualMenus.swift"; sourceTree = "<group>"; };
+		84E8E0EA202F693600562D8F /* DetailWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailWebView.swift; sourceTree = "<group>"; };
+		84E95D231FB1087500552D99 /* ArticlePasteboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticlePasteboardWriter.swift; sourceTree = "<group>"; };
+		84F204DF1FAACBB30076E152 /* ArticleArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleArray.swift; sourceTree = "<group>"; };
+		84F2D5351FC22FCB00998D64 /* PseudoFeed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PseudoFeed.swift; sourceTree = "<group>"; };
+		84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayFeedDelegate.swift; sourceTree = "<group>"; };
+		84F2D5391FC2308B00998D64 /* UnreadFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadFeed.swift; sourceTree = "<group>"; };
+		84F9EAD1213660A100CF2DE4 /* AppleScriptXCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleScriptXCTestCase.swift; sourceTree = "<group>"; };
+		84F9EAD2213660A100CF2DE4 /* ScriptingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptingTests.swift; sourceTree = "<group>"; };
+		84F9EAD4213660A100CF2DE4 /* testNameOfAuthors.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testNameOfAuthors.applescript; sourceTree = "<group>"; };
+		84F9EAD5213660A100CF2DE4 /* testGetURL.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testGetURL.applescript; sourceTree = "<group>"; };
+		84F9EAD6213660A100CF2DE4 /* testNameAndUrlOfEveryFeed.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testNameAndUrlOfEveryFeed.applescript; sourceTree = "<group>"; };
+		84F9EAD7213660A100CF2DE4 /* testFeedExists.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testFeedExists.applescript; sourceTree = "<group>"; };
+		84F9EAD8213660A100CF2DE4 /* testIterativeCreateAndDeleteFeed.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testIterativeCreateAndDeleteFeed.applescript; sourceTree = "<group>"; };
+		84F9EAD9213660A100CF2DE4 /* selectAFeed.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = selectAFeed.applescript; sourceTree = "<group>"; };
+		84F9EADA213660A100CF2DE4 /* uiScriptingTestSetup.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = uiScriptingTestSetup.applescript; sourceTree = "<group>"; };
+		84F9EADB213660A100CF2DE4 /* testURLsOfCurrentArticle.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testURLsOfCurrentArticle.applescript; sourceTree = "<group>"; };
+		84F9EADC213660A100CF2DE4 /* testNameOfEveryFolder.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testNameOfEveryFolder.applescript; sourceTree = "<group>"; };
+		84F9EADD213660A100CF2DE4 /* testFeedOPML.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testFeedOPML.applescript; sourceTree = "<group>"; };
+		84F9EADE213660A100CF2DE4 /* selectAnArticle.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = selectAnArticle.applescript; sourceTree = "<group>"; };
+		84F9EADF213660A100CF2DE4 /* testTitleOfArticlesWhose.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testTitleOfArticlesWhose.applescript; sourceTree = "<group>"; };
+		84F9EAE0213660A100CF2DE4 /* testCurrentArticleIsNil.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testCurrentArticleIsNil.applescript; sourceTree = "<group>"; };
+		84F9EAE1213660A100CF2DE4 /* testGenericScript.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = testGenericScript.applescript; sourceTree = "<group>"; };
+		84F9EAE2213660A100CF2DE4 /* establishMainWindowStartingState.applescript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.applescript; path = establishMainWindowStartingState.applescript; sourceTree = "<group>"; };
+		84F9EAE4213660A100CF2DE4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconURLFinder.swift; sourceTree = "<group>"; };
+		9EA33BB72318F8C10097B644 /* AccountsFeedlyWebWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountsFeedlyWebWindowController.swift; sourceTree = "<group>"; };
+		9EA33BB82318F8C10097B644 /* AccountsFeedlyWeb.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccountsFeedlyWeb.xib; sourceTree = "<group>"; };
+		B24EFD482330FF99006C6242 /* NetNewsWire-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NetNewsWire-Bridging-Header.h"; sourceTree = "<group>"; };
+		B24EFD5923310109006C6242 /* WKPreferencesPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPreferencesPrivate.h; sourceTree = "<group>"; };
+		B528F81D23333C7E00E735DD /* page.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = page.html; sourceTree = "<group>"; };
+		D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_safariextension_target.xcconfig; sourceTree = "<group>"; };
+		D553737C20186C1F006D8857 /* Article+Scriptability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Scriptability.swift"; sourceTree = "<group>"; };
+		D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScriptCommand+NetNewsWire.swift"; sourceTree = "<group>"; };
+		D5907CDC2002F0BE005947E5 /* NetNewsWire_project_release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_project_release.xcconfig; sourceTree = "<group>"; };
+		D5907CDD2002F0BE005947E5 /* NetNewsWire_project_debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_project_debug.xcconfig; sourceTree = "<group>"; };
+		D5907CDE2002F0BE005947E5 /* NetNewsWire_project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_project.xcconfig; sourceTree = "<group>"; };
+		D5907CDF2002F0F9005947E5 /* NetNewsWireTests_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWireTests_target.xcconfig; sourceTree = "<group>"; };
+		D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_macapp_target.xcconfig; sourceTree = "<group>"; };
+		D5907D7E2004AC00005947E5 /* NSApplication+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplication+Scriptability.swift"; sourceTree = "<group>"; };
+		D5907D962004B7EB005947E5 /* Account+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Scriptability.swift"; sourceTree = "<group>"; };
+		D5907DB12004BB37005947E5 /* ScriptingObjectContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptingObjectContainer.swift; sourceTree = "<group>"; };
+		D5A2678B20130ECF00A8D3C0 /* Author+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Author+Scriptability.swift"; sourceTree = "<group>"; };
+		D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Scriptability.swift"; sourceTree = "<group>"; };
+		D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainWindowController+Scriptability.swift"; sourceTree = "<group>"; };
+		D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptingObject.swift; sourceTree = "<group>"; };
+		D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feed+Scriptability.swift"; sourceTree = "<group>"; };
+		D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Folder+Scriptability.swift"; sourceTree = "<group>"; };
+		DD82AB09231003F6002269DF /* SharingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingTests.swift; sourceTree = "<group>"; };
+		FF3ABF09232599450074C542 /* ArticleSorterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSorterTests.swift; sourceTree = "<group>"; };
+		FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleSorter.swift; sourceTree = "<group>"; };
+		FFD43E372340F320009E5CA3 /* UndoAvailableAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoAvailableAlertController.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		51314634235A7BBE00387FDC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				513146B6235A8FD000387FDC /* RSDatabase.framework in Frameworks */,
+				513146BC235A8FD000387FDC /* RSWeb.framework in Frameworks */,
+				513146C3235A8FDB00387FDC /* ArticlesDatabase.framework in Frameworks */,
+				513146BF235A8FDB00387FDC /* Account.framework in Frameworks */,
+				513146C1235A8FDB00387FDC /* Articles.framework in Frameworks */,
+				513146BA235A8FD000387FDC /* RSTree.framework in Frameworks */,
+				513146C5235A8FDB00387FDC /* SyncDatabase.framework in Frameworks */,
+				513146B4235A8FD000387FDC /* RSCore.framework in Frameworks */,
+				513146B8235A8FD000387FDC /* RSParser.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		513C5CE3232571C2003D4054 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				513C5D0A232574D2003D4054 /* RSWeb.framework in Frameworks */,
+				513C5D0C232574DA003D4054 /* RSTree.framework in Frameworks */,
+				513C5CFD2325749A003D4054 /* Account.framework in Frameworks */,
+				513C5D00232574AF003D4054 /* Articles.framework in Frameworks */,
+				513C5D08232574C6003D4054 /* RSParser.framework in Frameworks */,
+				513C5D06232574C0003D4054 /* RSDatabase.framework in Frameworks */,
+				513C5D0E232574E4003D4054 /* SyncDatabase.framework in Frameworks */,
+				513C5D04232574B9003D4054 /* RSCore.framework in Frameworks */,
+				513C5D02232574B4003D4054 /* ArticlesDatabase.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		518B2ECF2351B3DD00400001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6581C73020CED60000F4AD34 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED4042235DEF6C0081F399 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED4043235DEF6C0081F399 /* RSWeb.framework in Frameworks */,
+				65ED4044235DEF6C0081F399 /* RSDatabase.framework in Frameworks */,
+				65ED4045235DEF6C0081F399 /* RSTree.framework in Frameworks */,
+				65ED4046235DEF6C0081F399 /* ArticlesDatabase.framework in Frameworks */,
+				65ED4047235DEF6C0081F399 /* RSParser.framework in Frameworks */,
+				65ED4048235DEF6C0081F399 /* Account.framework in Frameworks */,
+				65ED4049235DEF6C0081F399 /* Articles.framework in Frameworks */,
+				65ED404A235DEF6C0081F399 /* RSCore.framework in Frameworks */,
+				65ED404B235DEF6C0081F399 /* SyncDatabase.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED4094235DEF770081F399 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		840D61792029031C009BC708 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51C452B42265141B00C03939 /* WebKit.framework in Frameworks */,
+				51C451D22264C7F200C03939 /* RSWeb.framework in Frameworks */,
+				51C451E02264C7F900C03939 /* RSTree.framework in Frameworks */,
+				51C451F82264C83E00C03939 /* Account.framework in Frameworks */,
+				51C451F02264C83100C03939 /* ArticlesDatabase.framework in Frameworks */,
+				51C451F42264C83900C03939 /* Articles.framework in Frameworks */,
+				51C451E82264C81000C03939 /* RSDatabase.framework in Frameworks */,
+				51C451EC2264C81B00C03939 /* RSCore.framework in Frameworks */,
+				51554C30228B71A10055115A /* SyncDatabase.framework in Frameworks */,
+				51C451E42264C80600C03939 /* RSParser.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C645D1ED37A5D003D8FC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED42DE235E74230081F399 /* Sparkle.framework in Frameworks */,
+				65ED42D9235E740D0081F399 /* Sparkle.framework in Frameworks */,
+				84C37FA920DD8D9000CA8CF5 /* RSWeb.framework in Frameworks */,
+				84C37FC520DD8E1D00CA8CF5 /* RSDatabase.framework in Frameworks */,
+				84C37FAD20DD8D9900CA8CF5 /* RSTree.framework in Frameworks */,
+				51C451A9226377C200C03939 /* ArticlesDatabase.framework in Frameworks */,
+				84C37FB520DD8DBB00CA8CF5 /* RSParser.framework in Frameworks */,
+				51C451BD226377D000C03939 /* Account.framework in Frameworks */,
+				51C451B9226377C900C03939 /* Articles.framework in Frameworks */,
+				84C37FA520DD8D8400CA8CF5 /* RSCore.framework in Frameworks */,
+				51554C24228B71910055115A /* SyncDatabase.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C646E1ED37A5D003D8FC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		511D43CE231FA51100FB1562 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				844B5B641FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist */,
+				844B5B681FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist */,
+				845479871FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist */,
+				5127B237222B4849006D641D /* DetailKeyboardShortcuts.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		5123DB95233EC69300282CC9 /* Inspector */ = {
+			isa = PBXGroup;
+			children = (
+				516A09412361248000EAE89B /* Inspector.storyboard */,
+				51A16991235E10D600EB091F /* AccountInspectorViewController.swift */,
+				5123DB9E233EC6FD00282CC9 /* FeedInspectorView.swift */,
+			);
+			path = Inspector;
+			sourceTree = "<group>";
+		};
+		5127B235222B4849006D641D /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				5127B236222B4849006D641D /* DetailKeyboardDelegate.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		512E08DD22687FA000BDCFDD /* Tree */ = {
+			isa = PBXGroup;
+			children = (
+				51C452812265093600C03939 /* FlattenedAccountFolderPickerData.swift */,
+				849A97611ED9EB96007D329B /* FeedTreeControllerDelegate.swift */,
+				849A97A11ED9F180007D329B /* FolderTreeControllerDelegate.swift */,
+			);
+			path = Tree;
+			sourceTree = "<group>";
+		};
+		513145F9235A55A700387FDC /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				51314707235C41FC00387FDC /* Intents.intentdefinition */,
+				513146B1235A81A400387FDC /* AddFeedIntentHandler.swift */,
+			);
+			path = Intents;
+			sourceTree = "<group>";
+		};
+		51314643235A7C2300387FDC /* IntentsExtension */ = {
+			isa = PBXGroup;
+			children = (
+				51314666235A7E4600387FDC /* IntentHandler.swift */,
+				51314665235A7E4600387FDC /* Info.plist */,
+				51314684235A7EB900387FDC /* NetNewsWire_iOS_IntentsExtension.entitlements */,
+			);
+			path = IntentsExtension;
+			sourceTree = "<group>";
+		};
+		513228F1233037620033D4ED /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				513228F2233037620033D4ED /* Reachability.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		513C5CE7232571C2003D4054 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				513C5CE8232571C2003D4054 /* ShareViewController.swift */,
+				51707438232AA97100A461A3 /* ShareFolderPickerController.swift */,
+				513C5CEA232571C2003D4054 /* MainInterface.storyboard */,
+				513C5CED232571C2003D4054 /* Info.plist */,
+				515D4FCB2325815A00EE1167 /* SafariExt.js */,
+				515D4FCD2325909200EE1167 /* NetNewsWire_iOS_ShareExtension.entitlements */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+		5144EA39227A377700D19003 /* OPML */ = {
+			isa = PBXGroup;
+			children = (
+				5144EA3A227A379E00D19003 /* ImportOPMLSheet.xib */,
+				5144EA3E227A37EC00D19003 /* ImportOPMLWindowController.swift */,
+				849C78872362AAFB009A71E4 /* ExportOPMLSheet.xib */,
+				849C78912362AB04009A71E4 /* ExportOPMLWindowController.swift */,
+			);
+			path = OPML;
+			sourceTree = "<group>";
+		};
+		51554BFD228B6EB50055115A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				51554C01228B6EB50055115A /* SyncDatabase.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		516A093E236123A800EAE89B /* Account */ = {
+			isa = PBXGroup;
+			children = (
+				516A093F2361240900EAE89B /* Account.storyboard */,
+				51A1698F235E10D600EB091F /* LocalAccountViewController.swift */,
+				51A16996235E10D700EB091F /* FeedbinAccountViewController.swift */,
+			);
+			path = Account;
+			sourceTree = "<group>";
+		};
+		5183CCEA226F70350010922C /* Timer */ = {
+			isa = PBXGroup;
+			children = (
+				5183CCE4226F4DFA0010922C /* RefreshInterval.swift */,
+				5183CCE7226F68D90010922C /* AccountRefreshTimer.swift */,
+				51E595A4228CC36500FCC42B /* ArticleStatusSyncTimer.swift */,
+			);
+			path = Timer;
+			sourceTree = "<group>";
+		};
+		5183CCEB227117C70010922C /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				51A16990235E10D600EB091F /* Settings.storyboard */,
+				51A16995235E10D600EB091F /* AboutViewController.swift */,
+				51A16992235E10D600EB091F /* AddAccountViewController.swift */,
+				51A1698D235E10D600EB091F /* RefreshIntervalViewController.swift */,
+				516A09382360A2AE00EAE89B /* SettingsAccountTableViewCell.swift */,
+				516A091D23609A3600EAE89B /* SettingsAccountTableViewCell.xib */,
+				516A093A2360A4A000EAE89B /* SettingsTableViewCell.xib */,
+				51A16993235E10D600EB091F /* SettingsViewController.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		518651A423555EB20078E021 /* NNW3 */ = {
+			isa = PBXGroup;
+			children = (
+				849ADEE02359817D000E1B81 /* NNW3ImportController.swift */,
+				518651AB23555EB20078E021 /* NNW3Document.swift */,
+				849ADEE523598189000E1B81 /* NNW3OpenPanelAccessoryView.xib */,
+				849ADEE7235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift */,
+			);
+			path = NNW3;
+			sourceTree = "<group>";
+		};
+		51934CCC231078DC006127BE /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				51934CCD2310792F006127BE /* ActivityManager.swift */,
+				51D87EE02311D34700E63F03 /* ActivityType.swift */,
+			);
+			path = Activity;
+			sourceTree = "<group>";
+		};
+		519D740423243C68008BB345 /* Model Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				519D740523243CC0008BB345 /* RefreshInterval-Extensions.swift */,
+				51AF460D232488C6001742EF /* Account-Extensions.swift */,
+			);
+			path = "Model Extensions";
+			sourceTree = "<group>";
+		};
+		51C45245226506C800C03939 /* UIKit Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				51F85BFA2275D85000C787DC /* Array-Extensions.swift */,
+				51F85BF42273625800C787DC /* Bundle-Extensions.swift */,
+				51EAED95231363EF00A9EEE3 /* NonIntrinsicButton.swift */,
+				5183CCD9226E31A50010922C /* NonIntrinsicImageView.swift */,
+				5183CCCF226E1E880010922C /* NonIntrinsicLabel.swift */,
+				512363372369155100951F16 /* RoundedProgressView.swift */,
+				51C45250226506F400C03939 /* String-Extensions.swift */,
+				51934CC1230F5963006127BE /* ThemedNavigationController.swift */,
+				51F85BF82274AA7B00C787DC /* UIBarButtonItem-Extensions.swift */,
+				51F85BF622749FA100C787DC /* UIFont-Extensions.swift */,
+				51FD40BD2341555600880194 /* UIImage-Extensions.swift */,
+				512E092B2268B25500BDCFDD /* UISplitViewController-Extensions.swift */,
+				51C4524E226506F400C03939 /* UIStoryboard-Extensions.swift */,
+				51FFF0C3235EE8E5002762AA /* VibrantButton.swift */,
+				5186A634235EF3A800C97195 /* VibrantLabel.swift */,
+				5F323808231DF9F000706F6B /* VibrantTableViewCell.swift */,
+			);
+			path = "UIKit Extensions";
+			sourceTree = "<group>";
+		};
+		51C4525D226508F600C03939 /* MasterFeed */ = {
+			isa = PBXGroup;
+			children = (
+				51C45264226508F600C03939 /* MasterFeedViewController.swift */,
+				51CC9B3D231720B2000E842F /* MasterFeedDataSource.swift */,
+				51CE1C0A23622006005548FC /* RefreshProgressView.swift */,
+				51CE1C0823621EDA005548FC /* RefreshProgressView.xib */,
+				51C45260226508F600C03939 /* Cell */,
+			);
+			path = MasterFeed;
+			sourceTree = "<group>";
+		};
+		51C45260226508F600C03939 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				512E08F722688F7C00BDCFDD /* MasterFeedTableViewSectionHeader.swift */,
+				51C45262226508F600C03939 /* MasterFeedTableViewCell.swift */,
+				51C45263226508F600C03939 /* MasterFeedTableViewCellLayout.swift */,
+				51C45261226508F600C03939 /* MasterFeedUnreadCountView.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		51C4526D2265091600C03939 /* MasterTimeline */ = {
+			isa = PBXGroup;
+			children = (
+				51C4526E2265091600C03939 /* MasterTimelineViewController.swift */,
+				51D6A5BB23199C85001C27D8 /* MasterTimelineDataSource.swift */,
+				5148F4542336DB7000F8CD8B /* MasterTimelineTitleView.swift */,
+				5148F44A2336DB4700F8CD8B /* MasterTimelineTitleView.xib */,
+				51FD413A2342BD0500880194 /* MasterTimelineUnreadCountView.swift */,
+				FFD43E372340F320009E5CA3 /* UndoAvailableAlertController.swift */,
+				51C4526F2265091600C03939 /* Cell */,
+			);
+			path = MasterTimeline;
+			sourceTree = "<group>";
+		};
+		51C4526F2265091600C03939 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				51EF0F7D2277A57D0050506E /* MasterTimelineAccessibilityCellLayout.swift */,
+				51C452712265091600C03939 /* MasterTimelineCellData.swift */,
+				51EF0F7F2277A8330050506E /* MasterTimelineCellLayout.swift */,
+				51C452752265091600C03939 /* MasterTimelineDefaultCellLayout.swift */,
+				51C452722265091600C03939 /* MasterTimelineTableViewCell.swift */,
+				51C452742265091600C03939 /* MasterUnreadIndicatorView.swift */,
+				51C452702265091600C03939 /* MultilineUILabelSizer.swift */,
+				51F85BFC2275DCA800C787DC /* SingleLineUILabelSizer.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		51C4527D2265092C00C03939 /* Article */ = {
+			isa = PBXGroup;
+			children = (
+				51C4527E2265092C00C03939 /* ArticleViewController.swift */,
+				517630222336657E00E15FFF /* ArticleViewControllerWebViewProvider.swift */,
+				51102164233A7D6C0007A5F7 /* ArticleExtractorButton.swift */,
+				5142192923522B5500E07E2C /* ImageViewController.swift */,
+				514219362352510100E07E2C /* ImageScrollView.swift */,
+				518651D9235621840078E021 /* ImageTransition.swift */,
+			);
+			path = Article;
+			sourceTree = "<group>";
+		};
+		51C452802265093600C03939 /* Add */ = {
+			isa = PBXGroup;
+			children = (
+				51C452822265093600C03939 /* Add.storyboard */,
+				51121B5A22661FEF00BC0EC1 /* AddContainerViewController.swift */,
+				514B7D1E23219F3C00BAC947 /* AddControllerType.swift */,
+				51C452842265093600C03939 /* AddFeedViewController.swift */,
+				51C4528B2265095F00C03939 /* AddFolderViewController.swift */,
+			);
+			path = Add;
+			sourceTree = "<group>";
+		};
+		51C452A822650DA100C03939 /* Article Rendering */ = {
+			isa = PBXGroup;
+			children = (
+				49F40DEF2335B71000552BF4 /* newsfoot.js */,
+				849A977D1ED9EC42007D329B /* ArticleRenderer.swift */,
+				848362FE2262A30E00DA1D35 /* template.html */,
+				517630032336215100E15FFF /* main.js */,
+			);
+			path = "Article Rendering";
+			sourceTree = "<group>";
+		};
+		51C452AD2265102800C03939 /* Timeline */ = {
+			isa = PBXGroup;
+			children = (
+				84F204DF1FAACBB30076E152 /* ArticleArray.swift */,
+				FF3ABF1423259DDB0074C542 /* ArticleSorter.swift */,
+				84CAFCAE22BC8C35007694F0 /* FetchRequestOperation.swift */,
+				84CAFCA322BC8C08007694F0 /* FetchRequestQueue.swift */,
+			);
+			path = Timeline;
+			sourceTree = "<group>";
+		};
+		51C452B22265141B00C03939 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				51C452B32265141B00C03939 /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		51FA739A2332BDE70090D516 /* Article Extractor */ = {
+			isa = PBXGroup;
+			children = (
+				51FA73A92332C2FD0090D516 /* ArticleExtractorConfig.swift */,
+				51FA73A32332BE110090D516 /* ArticleExtractor.swift */,
+				51FA73A62332BE880090D516 /* ExtractedArticle.swift */,
+			);
+			path = "Article Extractor";
+			sourceTree = "<group>";
+		};
+		51FE0FF9234552490056195D /* UserNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				51FE10022345529D0056195D /* UserNotificationManager.swift */,
+			);
+			path = UserNotifications;
+			sourceTree = "<group>";
+		};
+		6581C73620CED60100F4AD34 /* SafariExtension */ = {
+			isa = PBXGroup;
+			children = (
+				6581C73720CED60100F4AD34 /* SafariExtensionHandler.swift */,
+				6581C73920CED60100F4AD34 /* SafariExtensionViewController.swift */,
+				6581C73B20CED60100F4AD34 /* SafariExtensionViewController.xib */,
+				6581C73E20CED60100F4AD34 /* Info.plist */,
+				6581C73F20CED60100F4AD34 /* netnewswire-subscribe-to-feed.js */,
+				6581C74120CED60100F4AD34 /* ToolbarItemIcon.pdf */,
+				6581C74320CED60100F4AD34 /* Subscribe_to_Feed.entitlements */,
+			);
+			path = SafariExtension;
+			sourceTree = "<group>";
+		};
+		65ED429A235E71B40081F399 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				65ED42B0235E71B40081F399 /* Sparkle.framework */,
+				65ED42B2235E71B40081F399 /* SparkleCore.framework */,
+				65ED42B4235E71B40081F399 /* Autoupdate */,
+				65ED42B6235E71B40081F399 /* org.sparkle-project.InstallerLauncher.xpc */,
+				65ED42B8235E71B40081F399 /* org.sparkle-project.InstallerConnection.xpc */,
+				65ED42BA235E71B40081F399 /* org.sparkle-project.InstallerStatus.xpc */,
+				65ED42BC235E71B40081F399 /* org.sparkle-project.Downloader.xpc */,
+				65ED42BE235E71B40081F399 /* Sparkle Test App.app */,
+				65ED42C0235E71B40081F399 /* TestAppHelper.xpc */,
+				65ED42C2235E71B40081F399 /* Sparkle Unit Tests.xctest */,
+				65ED42C4235E71B40081F399 /* BinaryDelta */,
+				65ED42C6235E71B40081F399 /* sparkle.app */,
+				65ED42C8235E71B40081F399 /* Updater.app */,
+				65ED42CA235E71B40081F399 /* UI Tests.xctest */,
+				65ED42CC235E71B40081F399 /* generate_appcast */,
+				65ED42CE235E71B40081F399 /* libbsdiff.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		840716652262A60D00344432 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8407166A2262A60D00344432 /* Account.framework */,
+				8407166C2262A60D00344432 /* AccountTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8407166E2262A60F00344432 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				840716732262A60F00344432 /* Articles.framework */,
+				840716752262A60F00344432 /* ArticlesTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8407167A2262A61100344432 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8407167F2262A61100344432 /* ArticlesDatabase.framework */,
+				840716812262A61100344432 /* ArticlesDatabaseTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		840D61942029031D009BC708 /* NetNewsWire-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				840D61952029031D009BC708 /* NetNewsWire_iOSTests.swift */,
+				840D61972029031D009BC708 /* Info.plist */,
+			);
+			path = "NetNewsWire-iOSTests";
+			sourceTree = "<group>";
+		};
+		8426119C1FCB6ED40086A189 /* HTMLMetadata */ = {
+			isa = PBXGroup;
+			children = (
+				8426119D1FCB6ED40086A189 /* HTMLMetadataDownloader.swift */,
+			);
+			path = HTMLMetadata;
+			sourceTree = "<group>";
+		};
+		842E45E11ED8C681000A8B52 /* MainWindow */ = {
+			isa = PBXGroup;
+			children = (
+				8483630C2262A3FE00DA1D35 /* MainWindow.storyboard */,
+				849A975D1ED9EB72007D329B /* MainWindowController.swift */,
+				519B8D322143397200FA689C /* SharingServiceDelegate.swift */,
+				849EE72020391F560082A1EA /* SharingServicePickerDelegate.swift */,
+				51FA73B62332D5F70090D516 /* ArticleExtractorButton.swift */,
+				844B5B6B1FEA224B00C7C76A /* Keyboard */,
+				849A975F1ED9EB95007D329B /* Sidebar */,
+				849A97681ED9EBC8007D329B /* Timeline */,
+				849A977C1ED9EC42007D329B /* Detail */,
+				849A97551ED9EAC3007D329B /* Add Feed */,
+				849A97411ED9EAA9007D329B /* Add Folder */,
+				5144EA39227A377700D19003 /* OPML */,
+				518651A423555EB20078E021 /* NNW3 */,
+			);
+			path = MainWindow;
+			sourceTree = "<group>";
+		};
+		8444C9011FED81880051386C /* Exporters */ = {
+			isa = PBXGroup;
+			children = (
+				8444C8F11FED81840051386C /* OPMLExporter.swift */,
+			);
+			path = Exporters;
+			sourceTree = "<group>";
+		};
+		844B5B6A1FEA224000C7C76A /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				844B5B581FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		844B5B6B1FEA224B00C7C76A /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				844B5B661FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		844B5B6C1FEA282400C7C76A /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				844B5B5A1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		845213211FCA5B10003B6E93 /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				845213221FCA5B10003B6E93 /* ImageDownloader.swift */,
+				84E850851FCB60CE0072EA88 /* AuthorAvatarDownloader.swift */,
+				842611891FCB67AA0086A189 /* FeedIconDownloader.swift */,
+				8426119F1FCB72600086A189 /* FeaturedImageDownloader.swift */,
+				842611A11FCB769D0086A189 /* RSHTMLMetadata+Extension.swift */,
+			);
+			path = Images;
+			sourceTree = "<group>";
+		};
+		845A29251FC928C7007B49E3 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				849A979E1ED9F130007D329B /* SidebarCell.swift */,
+				845A29231FC9255E007B49E3 /* SidebarCellAppearance.swift */,
+				845A29211FC9251E007B49E3 /* SidebarCellLayout.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		84702AB31FA27AE8006B8943 /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				84702AA31FA27AC0006B8943 /* MarkStatusCommand.swift */,
+				84162A142038C12C00035290 /* MarkCommandValidationStatus.swift */,
+				84B99C9C1FAE83C600ECDEDB /* DeleteCommand.swift */,
+				84A14FF220048CA70046AD9A /* SendToMicroBlogCommand.swift */,
+				84A1500420048DDF0046AD9A /* SendToMarsEditCommand.swift */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
+		848B937021C8C5540038DC0D /* CrashReporter */ = {
+			isa = PBXGroup;
+			children = (
+				84BAE64821CEDAF20046DB56 /* CrashReporterWindow.xib */,
+				848B937121C8C5540038DC0D /* CrashReporter.swift */,
+				840BEE4021D70E64009BBAFA /* CrashReportWindowController.swift */,
+			);
+			path = CrashReporter;
+			sourceTree = "<group>";
+		};
+		848F6AE31FC29CFA002D422E /* Favicons */ = {
+			isa = PBXGroup;
+			children = (
+				51EF0F78227716380050506E /* ColorHash.swift */,
+				848F6AE41FC29CFA002D422E /* FaviconDownloader.swift */,
+				51EF0F76227716200050506E /* FaviconGenerator.swift */,
+				84FF69B01FC3793300DC198E /* FaviconURLFinder.swift */,
+				845A29081FC74B8E007B49E3 /* SingleFaviconDownloader.swift */,
+			);
+			path = Favicons;
+			sourceTree = "<group>";
+		};
+		849A97411ED9EAA9007D329B /* Add Folder */ = {
+			isa = PBXGroup;
+			children = (
+				848363032262A3CC00DA1D35 /* AddFolderSheet.xib */,
+				849A97421ED9EAA9007D329B /* AddFolderWindowController.swift */,
+			);
+			name = "Add Folder";
+			path = AddFolder;
+			sourceTree = "<group>";
+		};
+		849A97551ED9EAC3007D329B /* Add Feed */ = {
+			isa = PBXGroup;
+			children = (
+				848363002262A3BC00DA1D35 /* AddFeedSheet.xib */,
+				849A97511ED9EAC0007D329B /* AddFeedController.swift */,
+				849A97521ED9EAC0007D329B /* AddFeedWindowController.swift */,
+				51EC114B2149FE3300B296E3 /* FolderTreeMenu.swift */,
+			);
+			name = "Add Feed";
+			sourceTree = "<group>";
+		};
+		849A97561ED9EB0D007D329B /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				849A97731ED9EC04007D329B /* ArticleStringFormatter.swift */,
+				849A97581ED9EB0D007D329B /* ArticleUtilities.swift */,
+				84411E701FE5FBFA004B527F /* SmallIconProvider.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		849A975F1ED9EB95007D329B /* Sidebar */ = {
+			isa = PBXGroup;
+			children = (
+				849A97621ED9EB96007D329B /* SidebarViewController.swift */,
+				84B7178B201E66580091657D /* SidebarViewController+ContextualMenus.swift */,
+				84AD1EBB2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift */,
+				849A97601ED9EB96007D329B /* SidebarOutlineView.swift */,
+				849A97631ED9EB96007D329B /* UnreadCountView.swift */,
+				848D578D21543519005FFAD5 /* PasteboardFeed.swift */,
+				84AD1EA92031617300BC20B7 /* PasteboardFolder.swift */,
+				849A97821ED9EC63007D329B /* SidebarStatusBarView.swift */,
+				844B5B6A1FEA224000C7C76A /* Keyboard */,
+				845A29251FC928C7007B49E3 /* Cell */,
+				84A37CB3201ECD610087C5AF /* Renaming */,
+			);
+			path = Sidebar;
+			sourceTree = "<group>";
+		};
+		849A97681ED9EBC8007D329B /* Timeline */ = {
+			isa = PBXGroup;
+			children = (
+				8405DDA422168C62008CE1BF /* TimelineContainerViewController.swift */,
+				8405DD9822153B6B008CE1BF /* TimelineContainerView.swift */,
+				8405DDA122168920008CE1BF /* TimelineTableView.xib */,
+				849A976B1ED9EBC8007D329B /* TimelineViewController.swift */,
+				84E8E0DA202EC49300562D8F /* TimelineViewController+ContextualMenus.swift */,
+				849A97691ED9EBC8007D329B /* TimelineTableRowView.swift */,
+				849A976A1ED9EBC8007D329B /* TimelineTableView.swift */,
+				844B5B6C1FEA282400C7C76A /* Keyboard */,
+				84E95D231FB1087500552D99 /* ArticlePasteboardWriter.swift */,
+				849A976F1ED9EC04007D329B /* Cell */,
+			);
+			path = Timeline;
+			sourceTree = "<group>";
+		};
+		849A976F1ED9EC04007D329B /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				849A97741ED9EC04007D329B /* TimelineTableCellView.swift */,
+				849A97701ED9EC04007D329B /* TimelineCellAppearance.swift */,
+				849A97721ED9EC04007D329B /* TimelineCellLayout.swift */,
+				84E185B2203B74E500F69BFA /* SingleLineTextFieldSizer.swift */,
+				84E185C2203BB12600F69BFA /* MultilineTextFieldSizer.swift */,
+				849A97711ED9EC04007D329B /* TimelineCellData.swift */,
+				849A97751ED9EC04007D329B /* UnreadIndicatorView.swift */,
+				847CD6C9232F4CBF00FAC46D /* TimelineAvatarView.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		849A977C1ED9EC42007D329B /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				849A977E1ED9EC42007D329B /* DetailViewController.swift */,
+				8405DD892213E0E3008CE1BF /* DetailContainerView.swift */,
+				84216D0222128B9D0049B9B9 /* DetailWebViewController.swift */,
+				84E8E0EA202F693600562D8F /* DetailWebView.swift */,
+				84D52E941FE588BB00D14F5B /* DetailStatusBarView.swift */,
+				B528F81D23333C7E00E735DD /* page.html */,
+				5142194A2353C1CF00E07E2C /* main_mac.js */,
+				848362FC2262A30800DA1D35 /* styleSheet.css */,
+				5127B235222B4849006D641D /* Keyboard */,
+			);
+			path = Detail;
+			sourceTree = "<group>";
+		};
+		849A97861ED9ECEF007D329B /* Article Styles */ = {
+			isa = PBXGroup;
+			children = (
+				849A97871ED9ECEF007D329B /* ArticleStyle.swift */,
+				849A97881ED9ECEF007D329B /* ArticleStylesManager.swift */,
+			);
+			name = "Article Styles";
+			path = Shared/ArticleStyles;
+			sourceTree = SOURCE_ROOT;
+		};
+		849A97961ED9EFAA007D329B /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				849A97971ED9EFAA007D329B /* Node-Extensions.swift */,
+				8405DD9B22153BD7008CE1BF /* NSView-Extensions.swift */,
+				51126DA3225FDE2F00722696 /* RSImage-Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		849C64571ED37A5D003D8FC0 = {
+			isa = PBXGroup;
+			children = (
+				845B14A51FC2299E0013CF92 /* README.md */,
+				84D2200922B0BC4B0019E085 /* CONTRIBUTING.md */,
+				84CBDDAE1FD3674C005A61AA /* Technotes */,
+				84C9FC6522629B3900D921D6 /* Mac */,
+				84C9FC922262A0E600D921D6 /* iOS */,
+				84C9FC6822629C9A00D921D6 /* Shared */,
+				84C9FCA52262A1E600D921D6 /* Tests */,
+				D5907CDA2002F084005947E5 /* xcconfig */,
+				849C64611ED37A5D003D8FC0 /* Products */,
+				84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */,
+				84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */,
+				84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */,
+				84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */,
+				84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */,
+				51C452B22265141B00C03939 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		849C64611ED37A5D003D8FC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				849C64601ED37A5D003D8FC0 /* NetNewsWire.app */,
+				849C64711ED37A5D003D8FC0 /* NetNewsWireTests.xctest */,
+				840D617C2029031C009BC708 /* NetNewsWire.app */,
+				6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */,
+				513C5CE6232571C2003D4054 /* NetNewsWire iOS Share Extension.appex */,
+				518B2ED22351B3DD00400001 /* NetNewsWire-iOSTests.xctest */,
+				51314637235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex */,
+				65ED4083235DEF6C0081F399 /* NetNewsWire.app */,
+				65ED409D235DEF770081F399 /* Subscribe to Feed.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84A37CB3201ECD610087C5AF /* Renaming */ = {
+			isa = PBXGroup;
+			children = (
+				848363092262A3F000DA1D35 /* RenameSheet.xib */,
+				84A37CB4201ECD610087C5AF /* RenameWindowController.swift */,
+			);
+			path = Renaming;
+			sourceTree = "<group>";
+		};
+		84BBB12A20142A4700F054F5 /* Inspector */ = {
+			isa = PBXGroup;
+			children = (
+				84BBB12B20142A4700F054F5 /* Inspector.storyboard */,
+				84BBB12C20142A4700F054F5 /* InspectorWindowController.swift */,
+				8472058020142E8900AD578B /* FeedInspectorViewController.swift */,
+				841ABA5D20145E9200980E11 /* FolderInspectorViewController.swift */,
+				841ABA5F20145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift */,
+				841ABA4D20145E7300980E11 /* NothingInspectorViewController.swift */,
+			);
+			path = Inspector;
+			sourceTree = "<group>";
+		};
+		84C37F7B20DD8CF200CA8CF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84C37F8120DD8CF200CA8CF5 /* RSCore.framework */,
+				84C37F8320DD8CF200CA8CF5 /* RSCoreTests.xctest */,
+				84C37F8520DD8CF200CA8CF5 /* RSCore.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84C37F8720DD8CF800CA8CF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */,
+				84C37F8E20DD8CF800CA8CF5 /* RSParserTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84C37F9020DD8CFD00CA8CF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */,
+				84C37F9720DD8CFE00CA8CF5 /* RSTreeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84C37F9920DD8D0400CA8CF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */,
+				84C37FA120DD8D0500CA8CF5 /* RSWebTests.xctest */,
+				84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84C37FBA20DD8E0C00CA8CF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */,
+				84C37FC220DD8E0C00CA8CF5 /* RSDatabaseTests.xctest */,
+				84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84C9FC6522629B3900D921D6 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				848363062262A3DD00DA1D35 /* Main.storyboard */,
+				84C9FC6622629B3900D921D6 /* AppDelegate.swift */,
+				84E46C7C1F75EF7B005ECFB3 /* AppDefaults.swift */,
+				849EE70E203919360082A1EA /* AppAssets.swift */,
+				842E45DC1ED8C54B000A8B52 /* Browser.swift */,
+				51E3EB32229AB02C00645299 /* ErrorHandler.swift */,
+				842E45E11ED8C681000A8B52 /* MainWindow */,
+				84BBB12A20142A4700F054F5 /* Inspector */,
+				84C9FC6922629E1200D921D6 /* Preferences */,
+				848B937021C8C5540038DC0D /* CrashReporter */,
+				D5907D6F2004AB67005947E5 /* Scriptability */,
+				6581C73620CED60100F4AD34 /* SafariExtension */,
+				84C9FC8322629E8F00D921D6 /* Resources */,
+				84FB9A2C1EDCD6A4003D53B9 /* Frameworks */,
+				B24EFD482330FF99006C6242 /* NetNewsWire-Bridging-Header.h */,
+				B24EFD5923310109006C6242 /* WKPreferencesPrivate.h */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		84C9FC6822629C9A00D921D6 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				846E77301F6EF5D600A165E2 /* Account.xcodeproj */,
+				841D4D542106B3D500DD04E6 /* Articles.xcodeproj */,
+				841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */,
+				51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */,
+				842E45CD1ED8C308000A8B52 /* AppNotifications.swift */,
+				51C452AD2265102800C03939 /* Timeline */,
+				84702AB31FA27AE8006B8943 /* Commands */,
+				51934CCC231078DC006127BE /* Activity */,
+				51FA739A2332BDE70090D516 /* Article Extractor */,
+				51C452A822650DA100C03939 /* Article Rendering */,
+				849A97861ED9ECEF007D329B /* Article Styles */,
+				84DAEE201F86CAE00058304B /* Importers */,
+				8444C9011FED81880051386C /* Exporters */,
+				51FE0FF9234552490056195D /* UserNotifications */,
+				84F2D5341FC22FCB00998D64 /* SmartFeeds */,
+				848F6AE31FC29CFA002D422E /* Favicons */,
+				845213211FCA5B10003B6E93 /* Images */,
+				8426119C1FCB6ED40086A189 /* HTMLMetadata */,
+				5183CCEA226F70350010922C /* Timer */,
+				849A97561ED9EB0D007D329B /* Data */,
+				512E08DD22687FA000BDCFDD /* Tree */,
+				849A97961ED9EFAA007D329B /* Extensions */,
+				513228F1233037620033D4ED /* Network */,
+				511D43CE231FA51100FB1562 /* Resources */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		84C9FC6922629E1200D921D6 /* Preferences */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FC8022629E4800D921D6 /* Preferences.storyboard */,
+				84C9FC6E22629E1200D921D6 /* PreferencesWindowController.swift */,
+				84C9FC6A22629E1200D921D6 /* Advanced */,
+				84C9FC6C22629E1200D921D6 /* General */,
+				84C9FC6F22629E1200D921D6 /* Accounts */,
+			);
+			path = Preferences;
+			sourceTree = "<group>";
+		};
+		84C9FC6A22629E1200D921D6 /* Advanced */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FC6B22629E1200D921D6 /* AdvancedPreferencesViewController.swift */,
+			);
+			path = Advanced;
+			sourceTree = "<group>";
+		};
+		84C9FC6C22629E1200D921D6 /* General */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FC6D22629E1200D921D6 /* GeneralPrefencesViewController.swift */,
+			);
+			path = General;
+			sourceTree = "<group>";
+		};
+		84C9FC6F22629E1200D921D6 /* Accounts */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FC7022629E1200D921D6 /* AccountsTableViewBackgroundView.swift */,
+				84C9FC7122629E1200D921D6 /* AccountsControlsBackgroundView.swift */,
+				84C9FC7222629E1200D921D6 /* AccountsPreferencesViewController.swift */,
+				51EF0F8D2279C9260050506E /* AccountsAdd.xib */,
+				51EF0F8F2279C9500050506E /* AccountsAddViewController.swift */,
+				51EF0F912279CA620050506E /* AccountsAddTableCellView.swift */,
+				84C9FC7422629E1200D921D6 /* AccountsDetail.xib */,
+				5144EA2E2279FAB600D19003 /* AccountsDetailViewController.swift */,
+				5144EA50227B8E4500D19003 /* AccountsFeedbin.xib */,
+				5144EA4F227B8E4500D19003 /* AccountsFeedbinWindowController.swift */,
+				9EA33BB82318F8C10097B644 /* AccountsFeedlyWeb.xib */,
+				9EA33BB72318F8C10097B644 /* AccountsFeedlyWebWindowController.swift */,
+				55E15BC1229D65A900D6602A /* AccountsReaderAPI.xib */,
+				55E15BCA229D65A900D6602A /* AccountsReaderAPIWindowController.swift */,
+				5144EA352279FC3D00D19003 /* AccountsAddLocal.xib */,
+				5144EA372279FC6200D19003 /* AccountsAddLocalWindowController.swift */,
+			);
+			path = Accounts;
+			sourceTree = "<group>";
+		};
+		84C9FC8322629E8F00D921D6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				849C64671ED37A5D003D8FC0 /* Assets.xcassets */,
+				84C9FC8922629E8F00D921D6 /* Credits.rtf */,
+				84C9FC8A22629E8F00D921D6 /* NetNewsWire.sdef */,
+				84C9FC9022629ECB00D921D6 /* NetNewsWire.entitlements */,
+				84C9FC9122629F2200D921D6 /* Info.plist */,
+				65ED409F235DEFF00081F399 /* container-migration.plist */,
+				84C9FC8622629E8F00D921D6 /* KeyboardShortcuts */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		84C9FC8622629E8F00D921D6 /* KeyboardShortcuts */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FC8722629E8F00D921D6 /* KeyboardShortcuts.html */,
+			);
+			path = KeyboardShortcuts;
+			sourceTree = "<group>";
+		};
+		84C9FC922262A0E600D921D6 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				84C9FCA22262A1B800D921D6 /* LaunchScreenPhone.storyboard */,
+				511D43ED231FBDE800FB1562 /* LaunchScreenPad.storyboard */,
+				84C9FC9F2262A1B300D921D6 /* Main.storyboard */,
+				840D617E2029031C009BC708 /* AppDelegate.swift */,
+				519E743422C663F900A78E47 /* SceneDelegate.swift */,
+				5126EE96226CB48A00C22AFC /* SceneCoordinator.swift */,
+				514B7C8223205EFB00BAC947 /* RootSplitViewController.swift */,
+				511D4410231FC02D00FB1562 /* KeyboardManager.swift */,
+				51C45254226507D200C03939 /* AppAssets.swift */,
+				51C45255226507D200C03939 /* AppDefaults.swift */,
+				51E3EB3C229AB08300645299 /* ErrorHandler.swift */,
+				51BB7C262335A8E5008E8144 /* ArticleActivityItemSource.swift */,
+				51B62E67233186730085F949 /* AvatarView.swift */,
+				51C4525D226508F600C03939 /* MasterFeed */,
+				51C4526D2265091600C03939 /* MasterTimeline */,
+				51C4527D2265092C00C03939 /* Article */,
+				516A093E236123A800EAE89B /* Account */,
+				51C452802265093600C03939 /* Add */,
+				5123DB95233EC69300282CC9 /* Inspector */,
+				513145F9235A55A700387FDC /* Intents */,
+				5183CCEB227117C70010922C /* Settings */,
+				519D740423243C68008BB345 /* Model Extensions */,
+				51C45245226506C800C03939 /* UIKit Extensions */,
+				513C5CE7232571C2003D4054 /* ShareExtension */,
+				51314643235A7C2300387FDC /* IntentsExtension */,
+				84C9FC9A2262A1A900D921D6 /* Resources */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		84C9FC9A2262A1A900D921D6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				51F85BEA22724CB600C787DC /* About.rtf */,
+				51F85BF02272524100C787DC /* Credits.rtf */,
+				51F85BEC227251DF00C787DC /* Acknowledgments.rtf */,
+				51F85BEE2272520B00C787DC /* Thanks.rtf */,
+				51F85BF22272531500C787DC /* Dedication.rtf */,
+				51BB7C302335ACDE008E8144 /* page.html */,
+				514219572353C28900E07E2C /* main_ios.js */,
+				51C452B72265178500C03939 /* styleSheet.css */,
+				84C9FC9B2262A1A900D921D6 /* Assets.xcassets */,
+				84C9FC9C2262A1A900D921D6 /* Info.plist */,
+				84BB0F812333426400DED65E /* NetNewsWire.entitlements */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		84C9FCA52262A1E600D921D6 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				84F9EACF213660A100CF2DE4 /* NetNewsWireTests */,
+				840D61942029031D009BC708 /* NetNewsWire-iOSTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		84DAEE201F86CAE00058304B /* Importers */ = {
+			isa = PBXGroup;
+			children = (
+				849A97591ED9EB0D007D329B /* DefaultFeedsImporter.swift */,
+				84A3EE52223B667F00557320 /* DefaultFeeds.opml */,
+			);
+			path = Importers;
+			sourceTree = "<group>";
+		};
+		84F2D5341FC22FCB00998D64 /* SmartFeeds */ = {
+			isa = PBXGroup;
+			children = (
+				84CC88171FE59CBF00644329 /* SmartFeedsController.swift */,
+				84F2D5351FC22FCB00998D64 /* PseudoFeed.swift */,
+				84F2D5391FC2308B00998D64 /* UnreadFeed.swift */,
+				845EE7C01FC2488C00854A1F /* SmartFeed.swift */,
+				84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */,
+				84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */,
+				845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */,
+				8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */,
+				51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */,
+				84AD1EB92031649C00BC20B7 /* SmartFeedPasteboardWriter.swift */,
+			);
+			path = SmartFeeds;
+			sourceTree = "<group>";
+		};
+		84F9EACF213660A100CF2DE4 /* NetNewsWireTests */ = {
+			isa = PBXGroup;
+			children = (
+				84F9EAD0213660A100CF2DE4 /* ScriptingTests */,
+				FF3ABF09232599450074C542 /* ArticleSorterTests.swift */,
+				DD82AB09231003F6002269DF /* SharingTests.swift */,
+				84F9EAE4213660A100CF2DE4 /* Info.plist */,
+			);
+			path = NetNewsWireTests;
+			sourceTree = "<group>";
+		};
+		84F9EAD0213660A100CF2DE4 /* ScriptingTests */ = {
+			isa = PBXGroup;
+			children = (
+				84F9EAD1213660A100CF2DE4 /* AppleScriptXCTestCase.swift */,
+				84F9EAD2213660A100CF2DE4 /* ScriptingTests.swift */,
+				847E64942262782F00E00365 /* NSAppleEventDescriptor+UserRecordFields.swift */,
+				84F9EAD3213660A100CF2DE4 /* scripts */,
+			);
+			path = ScriptingTests;
+			sourceTree = "<group>";
+		};
+		84F9EAD3213660A100CF2DE4 /* scripts */ = {
+			isa = PBXGroup;
+			children = (
+				84F9EAD4213660A100CF2DE4 /* testNameOfAuthors.applescript */,
+				84F9EAD5213660A100CF2DE4 /* testGetURL.applescript */,
+				84F9EAD6213660A100CF2DE4 /* testNameAndUrlOfEveryFeed.applescript */,
+				84F9EAD7213660A100CF2DE4 /* testFeedExists.applescript */,
+				84F9EAD8213660A100CF2DE4 /* testIterativeCreateAndDeleteFeed.applescript */,
+				84F9EAD9213660A100CF2DE4 /* selectAFeed.applescript */,
+				84F9EADA213660A100CF2DE4 /* uiScriptingTestSetup.applescript */,
+				84F9EADB213660A100CF2DE4 /* testURLsOfCurrentArticle.applescript */,
+				84F9EADC213660A100CF2DE4 /* testNameOfEveryFolder.applescript */,
+				84F9EADD213660A100CF2DE4 /* testFeedOPML.applescript */,
+				84F9EADE213660A100CF2DE4 /* selectAnArticle.applescript */,
+				84F9EADF213660A100CF2DE4 /* testTitleOfArticlesWhose.applescript */,
+				84F9EAE0213660A100CF2DE4 /* testCurrentArticleIsNil.applescript */,
+				84F9EAE1213660A100CF2DE4 /* testGenericScript.applescript */,
+				84F9EAE2213660A100CF2DE4 /* establishMainWindowStartingState.applescript */,
+			);
+			path = scripts;
+			sourceTree = "<group>";
+		};
+		84FB9A2C1EDCD6A4003D53B9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				847752FE2008879500D93690 /* CoreServices.framework */,
+				6581C73420CED60100F4AD34 /* Cocoa.framework */,
+				65ED4299235E71B40081F399 /* Sparkle.xcodeproj */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D5907CDA2002F084005947E5 /* xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				D5907CDD2002F0BE005947E5 /* NetNewsWire_project_debug.xcconfig */,
+				51EC892923511D3B0061B6F6 /* NetNewsWire_project_test.xcconfig */,
+				D5907CDC2002F0BE005947E5 /* NetNewsWire_project_release.xcconfig */,
+				D5907CDE2002F0BE005947E5 /* NetNewsWire_project.xcconfig */,
+				D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */,
+				65ED40F2235DF5E00081F399 /* NetNewsWire_macapp_target_macappstore.xcconfig */,
+				D5907CDF2002F0F9005947E5 /* NetNewsWireTests_target.xcconfig */,
+				D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */,
+				65ED4186235E045B0081F399 /* NetNewsWire_safariextension_target_macappstore.xcconfig */,
+				51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */,
+				51314617235A797400387FDC /* NetNewsWire_iOSintentextension_target.xcconfig */,
+				515D4FCE2325B3D000EE1167 /* NetNewsWire_iOSshareextension_target.xcconfig */,
+				518B2EE92351B4C200400001 /* NetNewsWire_iOSTests_target.xcconfig */,
+				6543108B2322D90900658221 /* common */,
+			);
+			path = xcconfig;
+			sourceTree = "<group>";
+		};
+		D5907D6F2004AB67005947E5 /* Scriptability */ = {
+			isa = PBXGroup;
+			children = (
+				D5907D962004B7EB005947E5 /* Account+Scriptability.swift */,
+				D5E4CC53202C1361009B4FFC /* AppDelegate+Scriptability.swift */,
+				D553737C20186C1F006D8857 /* Article+Scriptability.swift */,
+				D5A2678B20130ECF00A8D3C0 /* Author+Scriptability.swift */,
+				D5F4EDB620074D6500B9E363 /* Feed+Scriptability.swift */,
+				D5F4EDB820074D7C00B9E363 /* Folder+Scriptability.swift */,
+				D5E4CC63202C1AC1009B4FFC /* MainWindowController+Scriptability.swift */,
+				D5907D7E2004AC00005947E5 /* NSApplication+Scriptability.swift */,
+				D5907DB12004BB37005947E5 /* ScriptingObjectContainer.swift */,
+				D5F4EDB4200744A700B9E363 /* ScriptingObject.swift */,
+				D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */,
+			);
+			path = Scriptability;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		51314636235A7BBE00387FDC /* NetNewsWire iOS Intents Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5131463F235A7BBE00387FDC /* Build configuration list for PBXNativeTarget "NetNewsWire iOS Intents Extension" */;
+			buildPhases = (
+				51314633235A7BBE00387FDC /* Sources */,
+				51314634235A7BBE00387FDC /* Frameworks */,
+				51314635235A7BBE00387FDC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "NetNewsWire iOS Intents Extension";
+			productName = "NetNewsWire iOS Intents Extension";
+			productReference = 51314637235A7BBE00387FDC /* NetNewsWire iOS Intents Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		513C5CE5232571C2003D4054 /* NetNewsWire iOS Share Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 513C5CFC232571C2003D4054 /* Build configuration list for PBXNativeTarget "NetNewsWire iOS Share Extension" */;
+			buildPhases = (
+				513C5CE2232571C2003D4054 /* Sources */,
+				513C5CE3232571C2003D4054 /* Frameworks */,
+				513C5CE4232571C2003D4054 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "NetNewsWire iOS Share Extension";
+			productName = "NetNewsWire iOS Share Extension";
+			productReference = 513C5CE6232571C2003D4054 /* NetNewsWire iOS Share Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		518B2ED12351B3DD00400001 /* NetNewsWire-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 518B2EE72351B3DD00400001 /* Build configuration list for PBXNativeTarget "NetNewsWire-iOSTests" */;
+			buildPhases = (
+				518B2ECE2351B3DD00400001 /* Sources */,
+				518B2ECF2351B3DD00400001 /* Frameworks */,
+				518B2ED02351B3DD00400001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				518B2ED82351B3DD00400001 /* PBXTargetDependency */,
+			);
+			name = "NetNewsWire-iOSTests";
+			productName = "NetNewsWire-iOSTests";
+			productReference = 518B2ED22351B3DD00400001 /* NetNewsWire-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6581C73220CED60000F4AD34 /* Subscribe to Feed */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6581C75620CED60100F4AD34 /* Build configuration list for PBXNativeTarget "Subscribe to Feed" */;
+			buildPhases = (
+				6581C72F20CED60000F4AD34 /* Sources */,
+				6581C73020CED60000F4AD34 /* Frameworks */,
+				6581C73120CED60000F4AD34 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Subscribe to Feed";
+			productName = "Subscribe to Feed";
+			productReference = 6581C73320CED60000F4AD34 /* Subscribe to Feed.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		65ED3FA2235DEF6C0081F399 /* NetNewsWire MAS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65ED407F235DEF6C0081F399 /* Build configuration list for PBXNativeTarget "NetNewsWire MAS" */;
+			buildPhases = (
+				65ED3FB5235DEF6C0081F399 /* Run Script: Update ArticleExtractorConfig.swift */,
+				65ED3FB6235DEF6C0081F399 /* Sources */,
+				65ED4041235DEF6C0081F399 /* Run Script: Reset ArticleExtractorConfig.swift */,
+				65ED4042235DEF6C0081F399 /* Frameworks */,
+				65ED404D235DEF6C0081F399 /* Resources */,
+				65ED406F235DEF6C0081F399 /* Run Script: Automated build numbers */,
+				65ED4070235DEF6C0081F399 /* Embed Frameworks */,
+				65ED407B235DEF6C0081F399 /* Embed App Extensions */,
+				65ED407D235DEF6C0081F399 /* Run Script: Verify No Build Settings */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				65ED41C7235E615E0081F399 /* PBXTargetDependency */,
+				65ED3FA3235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FA5235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FA7235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FA9235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FAB235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FAD235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FAF235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FB1235DEF6C0081F399 /* PBXTargetDependency */,
+				65ED3FB3235DEF6C0081F399 /* PBXTargetDependency */,
+			);
+			name = "NetNewsWire MAS";
+			productName = NetNewsWire;
+			productReference = 65ED4083235DEF6C0081F399 /* NetNewsWire.app */;
+			productType = "com.apple.product-type.application";
+		};
+		65ED4090235DEF770081F399 /* Subscribe to Feed MAS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65ED4099235DEF770081F399 /* Build configuration list for PBXNativeTarget "Subscribe to Feed MAS" */;
+			buildPhases = (
+				65ED4091235DEF770081F399 /* Sources */,
+				65ED4094235DEF770081F399 /* Frameworks */,
+				65ED4095235DEF770081F399 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Subscribe to Feed MAS";
+			productName = "Subscribe to Feed";
+			productReference = 65ED409D235DEF770081F399 /* Subscribe to Feed.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		840D617B2029031C009BC708 /* NetNewsWire-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 840D61A32029031E009BC708 /* Build configuration list for PBXNativeTarget "NetNewsWire-iOS" */;
+			buildPhases = (
+				517D2D80233A46ED00FF3E35 /* Run Script: Update ArticleExtractorConfig.swift */,
+				840D61782029031C009BC708 /* Sources */,
+				517D2D81233A47AD00FF3E35 /* Run Script: Reset ArticleExtractorConfig.swift */,
+				840D61792029031C009BC708 /* Frameworks */,
+				840D617A2029031C009BC708 /* Resources */,
+				51C451DF2264C7F200C03939 /* Embed Frameworks */,
+				513C5CF1232571C2003D4054 /* Embed App Extensions */,
+				515D50802326D02600EE1167 /* Run Script: Verify No Build Settings */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5131463D235A7BBE00387FDC /* PBXTargetDependency */,
+			);
+			name = "NetNewsWire-iOS";
+			productName = "NetNewsWire-iOS";
+			productReference = 840D617C2029031C009BC708 /* NetNewsWire.app */;
+			productType = "com.apple.product-type.application";
+		};
+		849C645F1ED37A5D003D8FC0 /* NetNewsWire */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 849C647A1ED37A5D003D8FC0 /* Build configuration list for PBXNativeTarget "NetNewsWire" */;
+			buildPhases = (
+				51D6803823330CFF0097A009 /* Run Script: Update ArticleExtractorConfig.swift */,
+				849C645C1ED37A5D003D8FC0 /* Sources */,
+				517D2D82233A53D600FF3E35 /* Run Script: Reset ArticleExtractorConfig.swift */,
+				849C645D1ED37A5D003D8FC0 /* Frameworks */,
+				849C645E1ED37A5D003D8FC0 /* Resources */,
+				84C987A52000AC9E0066B150 /* Run Script: Automated build numbers */,
+				84B06F681ED37B9000F0B54B /* Embed Frameworks */,
+				6581C75720CED60100F4AD34 /* Embed App Extensions */,
+				65ED42E0235E74240081F399 /* Embed XPC Services */,
+				D519E77022EE5B4100923F27 /* Run Script: Verify No Build Settings */,
+				8423E3E3220158E700C3795B /* Run Script: Code Sign Sparkle */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				65ED41C5235E61550081F399 /* PBXTargetDependency */,
+				84C37FA820DD8D8400CA8CF5 /* PBXTargetDependency */,
+				84C37FAC20DD8D9000CA8CF5 /* PBXTargetDependency */,
+				84C37FB020DD8D9900CA8CF5 /* PBXTargetDependency */,
+				84C37FB820DD8DBB00CA8CF5 /* PBXTargetDependency */,
+				84C37FC820DD8E1D00CA8CF5 /* PBXTargetDependency */,
+				51C451AC226377C300C03939 /* PBXTargetDependency */,
+				51C451BC226377C900C03939 /* PBXTargetDependency */,
+				51C451C0226377D000C03939 /* PBXTargetDependency */,
+				51554C27228B71910055115A /* PBXTargetDependency */,
+				65ED42D0235E71F60081F399 /* PBXTargetDependency */,
+				65ED42D2235E72000081F399 /* PBXTargetDependency */,
+				65ED42D4235E72000081F399 /* PBXTargetDependency */,
+				65ED42D6235E72000081F399 /* PBXTargetDependency */,
+				65ED42D8235E72000081F399 /* PBXTargetDependency */,
+			);
+			name = NetNewsWire;
+			productName = NetNewsWire;
+			productReference = 849C64601ED37A5D003D8FC0 /* NetNewsWire.app */;
+			productType = "com.apple.product-type.application";
+		};
+		849C64701ED37A5D003D8FC0 /* NetNewsWireTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 849C647D1ED37A5D003D8FC0 /* Build configuration list for PBXNativeTarget "NetNewsWireTests" */;
+			buildPhases = (
+				849C646D1ED37A5D003D8FC0 /* Sources */,
+				849C646E1ED37A5D003D8FC0 /* Frameworks */,
+				849C646F1ED37A5D003D8FC0 /* Resources */,
+				D5907C9B20022EC7005947E5 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				849C64731ED37A5D003D8FC0 /* PBXTargetDependency */,
+			);
+			name = NetNewsWireTests;
+			productName = NetNewsWireTests;
+			productReference = 849C64711ED37A5D003D8FC0 /* NetNewsWireTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		849C64581ED37A5D003D8FC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1120;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = "Ranchero Software";
+				TargetAttributes = {
+					51314636235A7BBE00387FDC = {
+						CreatedOnToolsVersion = 11.2;
+						DevelopmentTeam = SHJK2V3AJG;
+						LastSwiftMigration = 1120;
+						ProvisioningStyle = Automatic;
+					};
+					513C5CE5232571C2003D4054 = {
+						CreatedOnToolsVersion = 11.0;
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+					};
+					518B2ED12351B3DD00400001 = {
+						CreatedOnToolsVersion = 11.2;
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 840D617B2029031C009BC708;
+					};
+					6581C73220CED60000F4AD34 = {
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+					};
+					65ED3FA2235DEF6C0081F399 = {
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+					};
+					65ED4090235DEF770081F399 = {
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+					};
+					840D617B2029031C009BC708 = {
+						CreatedOnToolsVersion = 9.3;
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
+					};
+					849C645F1ED37A5D003D8FC0 = {
+						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.HardenedRuntime = {
+								enabled = 1;
+							};
+						};
+					};
+					849C64701ED37A5D003D8FC0 = {
+						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = SHJK2V3AJG;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 849C645F1ED37A5D003D8FC0;
+					};
+				};
+			};
+			buildConfigurationList = 849C645B1ED37A5D003D8FC0 /* Build configuration list for PBXProject "NetNewsWire" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+				Base,
+			);
+			mainGroup = 849C64571ED37A5D003D8FC0;
+			productRefGroup = 849C64611ED37A5D003D8FC0 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 840716652262A60D00344432 /* Products */;
+					ProjectRef = 846E77301F6EF5D600A165E2 /* Account.xcodeproj */;
+				},
+				{
+					ProductGroup = 8407166E2262A60F00344432 /* Products */;
+					ProjectRef = 841D4D542106B3D500DD04E6 /* Articles.xcodeproj */;
+				},
+				{
+					ProductGroup = 8407167A2262A61100344432 /* Products */;
+					ProjectRef = 841D4D5E2106B3E100DD04E6 /* ArticlesDatabase.xcodeproj */;
+				},
+				{
+					ProductGroup = 84C37F7B20DD8CF200CA8CF5 /* Products */;
+					ProjectRef = 84C37F7A20DD8CF200CA8CF5 /* RSCore.xcodeproj */;
+				},
+				{
+					ProductGroup = 84C37FBA20DD8E0C00CA8CF5 /* Products */;
+					ProjectRef = 84C37FB920DD8E0C00CA8CF5 /* RSDatabase.xcodeproj */;
+				},
+				{
+					ProductGroup = 84C37F8720DD8CF800CA8CF5 /* Products */;
+					ProjectRef = 84C37F8620DD8CF800CA8CF5 /* RSParser.xcodeproj */;
+				},
+				{
+					ProductGroup = 84C37F9020DD8CFD00CA8CF5 /* Products */;
+					ProjectRef = 84C37F8F20DD8CFD00CA8CF5 /* RSTree.xcodeproj */;
+				},
+				{
+					ProductGroup = 84C37F9920DD8D0400CA8CF5 /* Products */;
+					ProjectRef = 84C37F9820DD8D0400CA8CF5 /* RSWeb.xcodeproj */;
+				},
+				{
+					ProductGroup = 65ED429A235E71B40081F399 /* Products */;
+					ProjectRef = 65ED4299235E71B40081F399 /* Sparkle.xcodeproj */;
+				},
+				{
+					ProductGroup = 51554BFD228B6EB50055115A /* Products */;
+					ProjectRef = 51554BFC228B6EB50055115A /* SyncDatabase.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				849C645F1ED37A5D003D8FC0 /* NetNewsWire */,
+				65ED3FA2235DEF6C0081F399 /* NetNewsWire MAS */,
+				849C64701ED37A5D003D8FC0 /* NetNewsWireTests */,
+				840D617B2029031C009BC708 /* NetNewsWire-iOS */,
+				6581C73220CED60000F4AD34 /* Subscribe to Feed */,
+				65ED4090235DEF770081F399 /* Subscribe to Feed MAS */,
+				513C5CE5232571C2003D4054 /* NetNewsWire iOS Share Extension */,
+				51314636235A7BBE00387FDC /* NetNewsWire iOS Intents Extension */,
+				518B2ED12351B3DD00400001 /* NetNewsWire-iOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		51554C01228B6EB50055115A /* SyncDatabase.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SyncDatabase.framework;
+			remoteRef = 51554C00228B6EB50055115A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42B0235E71B40081F399 /* Sparkle.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Sparkle.framework;
+			remoteRef = 65ED42AF235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42B2235E71B40081F399 /* SparkleCore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SparkleCore.framework;
+			remoteRef = 65ED42B1235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42B4235E71B40081F399 /* Autoupdate */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = Autoupdate;
+			remoteRef = 65ED42B3235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42B6235E71B40081F399 /* org.sparkle-project.InstallerLauncher.xpc */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.xpc-service";
+			path = "org.sparkle-project.InstallerLauncher.xpc";
+			remoteRef = 65ED42B5235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42B8235E71B40081F399 /* org.sparkle-project.InstallerConnection.xpc */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.xpc-service";
+			path = "org.sparkle-project.InstallerConnection.xpc";
+			remoteRef = 65ED42B7235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42BA235E71B40081F399 /* org.sparkle-project.InstallerStatus.xpc */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.xpc-service";
+			path = "org.sparkle-project.InstallerStatus.xpc";
+			remoteRef = 65ED42B9235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42BC235E71B40081F399 /* org.sparkle-project.Downloader.xpc */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.xpc-service";
+			path = "org.sparkle-project.Downloader.xpc";
+			remoteRef = 65ED42BB235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42BE235E71B40081F399 /* Sparkle Test App.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = "Sparkle Test App.app";
+			remoteRef = 65ED42BD235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42C0235E71B40081F399 /* TestAppHelper.xpc */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.xpc-service";
+			path = TestAppHelper.xpc;
+			remoteRef = 65ED42BF235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42C2235E71B40081F399 /* Sparkle Unit Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Sparkle Unit Tests.xctest";
+			remoteRef = 65ED42C1235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42C4235E71B40081F399 /* BinaryDelta */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = BinaryDelta;
+			remoteRef = 65ED42C3235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42C6235E71B40081F399 /* sparkle.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = sparkle.app;
+			remoteRef = 65ED42C5235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42C8235E71B40081F399 /* Updater.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = Updater.app;
+			remoteRef = 65ED42C7235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42CA235E71B40081F399 /* UI Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "UI Tests.xctest";
+			remoteRef = 65ED42C9235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42CC235E71B40081F399 /* generate_appcast */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = generate_appcast;
+			remoteRef = 65ED42CB235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		65ED42CE235E71B40081F399 /* libbsdiff.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libbsdiff.a;
+			remoteRef = 65ED42CD235E71B40081F399 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8407166A2262A60D00344432 /* Account.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Account.framework;
+			remoteRef = 840716692262A60D00344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8407166C2262A60D00344432 /* AccountTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = AccountTests.xctest;
+			remoteRef = 8407166B2262A60D00344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		840716732262A60F00344432 /* Articles.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Articles.framework;
+			remoteRef = 840716722262A60F00344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		840716752262A60F00344432 /* ArticlesTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ArticlesTests.xctest;
+			remoteRef = 840716742262A60F00344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8407167F2262A61100344432 /* ArticlesDatabase.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ArticlesDatabase.framework;
+			remoteRef = 8407167E2262A61100344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		840716812262A61100344432 /* ArticlesDatabaseTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ArticlesDatabaseTests.xctest;
+			remoteRef = 840716802262A61100344432 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F8120DD8CF200CA8CF5 /* RSCore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSCore.framework;
+			remoteRef = 84C37F8020DD8CF200CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F8320DD8CF200CA8CF5 /* RSCoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RSCoreTests.xctest;
+			remoteRef = 84C37F8220DD8CF200CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F8520DD8CF200CA8CF5 /* RSCore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSCore.framework;
+			remoteRef = 84C37F8420DD8CF200CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F8C20DD8CF800CA8CF5 /* RSParser.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSParser.framework;
+			remoteRef = 84C37F8B20DD8CF800CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F8E20DD8CF800CA8CF5 /* RSParserTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RSParserTests.xctest;
+			remoteRef = 84C37F8D20DD8CF800CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F9520DD8CFE00CA8CF5 /* RSTree.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSTree.framework;
+			remoteRef = 84C37F9420DD8CFE00CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F9720DD8CFE00CA8CF5 /* RSTreeTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RSTreeTests.xctest;
+			remoteRef = 84C37F9620DD8CFE00CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37F9F20DD8D0500CA8CF5 /* RSWeb.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSWeb.framework;
+			remoteRef = 84C37F9E20DD8D0500CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37FA120DD8D0500CA8CF5 /* RSWebTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RSWebTests.xctest;
+			remoteRef = 84C37FA020DD8D0500CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37FA320DD8D0500CA8CF5 /* RSWeb.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSWeb.framework;
+			remoteRef = 84C37FA220DD8D0500CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37FC020DD8E0C00CA8CF5 /* RSDatabase.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSDatabase.framework;
+			remoteRef = 84C37FBF20DD8E0C00CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37FC220DD8E0C00CA8CF5 /* RSDatabaseTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RSDatabaseTests.xctest;
+			remoteRef = 84C37FC120DD8E0C00CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		84C37FC420DD8E0C00CA8CF5 /* RSDatabase.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RSDatabase.framework;
+			remoteRef = 84C37FC320DD8E0C00CA8CF5 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		51314635235A7BBE00387FDC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		513C5CE4232571C2003D4054 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				515D4FCC2325815A00EE1167 /* SafariExt.js in Resources */,
+				513C5CEC232571C2003D4054 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		518B2ED02351B3DD00400001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6581C73120CED60000F4AD34 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6581C74220CED60100F4AD34 /* ToolbarItemIcon.pdf in Resources */,
+				6581C73D20CED60100F4AD34 /* SafariExtensionViewController.xib in Resources */,
+				6581C74020CED60100F4AD34 /* netnewswire-subscribe-to-feed.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED404D235DEF6C0081F399 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED404E235DEF6C0081F399 /* NNW3OpenPanelAccessoryView.xib in Resources */,
+				65ED404F235DEF6C0081F399 /* GlobalKeyboardShortcuts.plist in Resources */,
+				65ED4050235DEF6C0081F399 /* DetailKeyboardShortcuts.plist in Resources */,
+				65ED4051235DEF6C0081F399 /* TimelineKeyboardShortcuts.plist in Resources */,
+				65ED4052235DEF6C0081F399 /* template.html in Resources */,
+				65ED4053235DEF6C0081F399 /* AccountsFeedlyWeb.xib in Resources */,
+				65ED4054235DEF6C0081F399 /* Main.storyboard in Resources */,
+				65ED4055235DEF6C0081F399 /* AccountsAdd.xib in Resources */,
+				65ED4056235DEF6C0081F399 /* NetNewsWire.sdef in Resources */,
+				65ED4057235DEF6C0081F399 /* AccountsDetail.xib in Resources */,
+				65ED4058235DEF6C0081F399 /* main.js in Resources */,
+				65ED40A1235DEFF00081F399 /* container-migration.plist in Resources */,
+				65ED4059235DEF6C0081F399 /* AccountsAddLocal.xib in Resources */,
+				65ED405A235DEF6C0081F399 /* main_mac.js in Resources */,
+				65ED405B235DEF6C0081F399 /* KeyboardShortcuts.html in Resources */,
+				65ED405C235DEF6C0081F399 /* ImportOPMLSheet.xib in Resources */,
+				65ED405D235DEF6C0081F399 /* SidebarKeyboardShortcuts.plist in Resources */,
+				65ED405E235DEF6C0081F399 /* DefaultFeeds.opml in Resources */,
+				65ED405F235DEF6C0081F399 /* Preferences.storyboard in Resources */,
+				65ED4060235DEF6C0081F399 /* (null) in Resources */,
+				65ED4061235DEF6C0081F399 /* Assets.xcassets in Resources */,
+				65ED4062235DEF6C0081F399 /* styleSheet.css in Resources */,
+				65ED4063235DEF6C0081F399 /* RenameSheet.xib in Resources */,
+				65ED4064235DEF6C0081F399 /* AddFolderSheet.xib in Resources */,
+				65ED4065235DEF6C0081F399 /* AccountsFeedbin.xib in Resources */,
+				65ED4066235DEF6C0081F399 /* TimelineTableView.xib in Resources */,
+				65ED4067235DEF6C0081F399 /* page.html in Resources */,
+				65ED4068235DEF6C0081F399 /* MainWindow.storyboard in Resources */,
+				65ED4069235DEF6C0081F399 /* AccountsReaderAPI.xib in Resources */,
+				65ED406A235DEF6C0081F399 /* newsfoot.js in Resources */,
+				65ED406B235DEF6C0081F399 /* CrashReporterWindow.xib in Resources */,
+				65ED406C235DEF6C0081F399 /* Credits.rtf in Resources */,
+				65ED406D235DEF6C0081F399 /* Inspector.storyboard in Resources */,
+				65ED406E235DEF6C0081F399 /* AddFeedSheet.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED4095235DEF770081F399 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED4096235DEF770081F399 /* ToolbarItemIcon.pdf in Resources */,
+				65ED4097235DEF770081F399 /* SafariExtensionViewController.xib in Resources */,
+				65ED4098235DEF770081F399 /* netnewswire-subscribe-to-feed.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		840D617A2029031C009BC708 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				517630052336215100E15FFF /* main.js in Resources */,
+				5148F44B2336DB4700F8CD8B /* MasterTimelineTitleView.xib in Resources */,
+				511D43D0231FA62500FB1562 /* TimelineKeyboardShortcuts.plist in Resources */,
+				51C452862265093600C03939 /* Add.storyboard in Resources */,
+				511D43EF231FBDE900FB1562 /* LaunchScreenPad.storyboard in Resources */,
+				511D43D2231FA62C00FB1562 /* GlobalKeyboardShortcuts.plist in Resources */,
+				84C9FCA12262A1B300D921D6 /* Main.storyboard in Resources */,
+				51BB7C312335ACDE008E8144 /* page.html in Resources */,
+				516A093723609A3600EAE89B /* SettingsAccountTableViewCell.xib in Resources */,
+				51F85BF32272531500C787DC /* Dedication.rtf in Resources */,
+				516A09422361248000EAE89B /* Inspector.storyboard in Resources */,
+				84C9FCA42262A1B800D921D6 /* LaunchScreenPhone.storyboard in Resources */,
+				51F85BEB22724CB600C787DC /* About.rtf in Resources */,
+				51F85BED227251DF00C787DC /* Acknowledgments.rtf in Resources */,
+				516A093B2360A4A000EAE89B /* SettingsTableViewCell.xib in Resources */,
+				511D43D1231FA62800FB1562 /* SidebarKeyboardShortcuts.plist in Resources */,
+				516A09402361240900EAE89B /* Account.storyboard in Resources */,
+				51C452AB22650DC600C03939 /* template.html in Resources */,
+				51F85BF12272524100C787DC /* Credits.rtf in Resources */,
+				84A3EE61223B667F00557320 /* DefaultFeeds.opml in Resources */,
+				511D43CF231FA62200FB1562 /* DetailKeyboardShortcuts.plist in Resources */,
+				51A1699A235E10D700EB091F /* Settings.storyboard in Resources */,
+				49F40DF92335B71000552BF4 /* newsfoot.js in Resources */,
+				51F85BEF2272520B00C787DC /* Thanks.rtf in Resources */,
+				51CE1C0923621EDA005548FC /* RefreshProgressView.xib in Resources */,
+				84C9FC9D2262A1A900D921D6 /* Assets.xcassets in Resources */,
+				514219582353C28900E07E2C /* main_ios.js in Resources */,
+				51C452B82265178500C03939 /* styleSheet.css in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C645E1ED37A5D003D8FC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				849ADEE623598189000E1B81 /* NNW3OpenPanelAccessoryView.xib in Resources */,
+				844B5B651FEA11F200C7C76A /* GlobalKeyboardShortcuts.plist in Resources */,
+				5127B23A222B4849006D641D /* DetailKeyboardShortcuts.plist in Resources */,
+				845479881FEB77C000AD8B59 /* TimelineKeyboardShortcuts.plist in Resources */,
+				848362FF2262A30E00DA1D35 /* template.html in Resources */,
+				9EA33BBA2318F8C10097B644 /* AccountsFeedlyWeb.xib in Resources */,
+				848363082262A3DD00DA1D35 /* Main.storyboard in Resources */,
+				51EF0F8E2279C9260050506E /* AccountsAdd.xib in Resources */,
+				84C9FC8F22629E8F00D921D6 /* NetNewsWire.sdef in Resources */,
+				84C9FC7D22629E1200D921D6 /* AccountsDetail.xib in Resources */,
+				517630042336215100E15FFF /* main.js in Resources */,
+				65ED40A0235DEFF00081F399 /* container-migration.plist in Resources */,
+				5144EA362279FC3D00D19003 /* AccountsAddLocal.xib in Resources */,
+				5142194B2353C1CF00E07E2C /* main_mac.js in Resources */,
+				84C9FC8C22629E8F00D921D6 /* KeyboardShortcuts.html in Resources */,
+				5144EA3B227A379E00D19003 /* ImportOPMLSheet.xib in Resources */,
+				844B5B691FEA20DF00C7C76A /* SidebarKeyboardShortcuts.plist in Resources */,
+				84A3EE5F223B667F00557320 /* DefaultFeeds.opml in Resources */,
+				849C78902362AAFC009A71E4 /* ExportOPMLSheet.xib in Resources */,
+				84C9FC8222629E4800D921D6 /* Preferences.storyboard in Resources */,
+				849C64681ED37A5D003D8FC0 /* Assets.xcassets in Resources */,
+				848362FD2262A30800DA1D35 /* styleSheet.css in Resources */,
+				8483630B2262A3F000DA1D35 /* RenameSheet.xib in Resources */,
+				848363052262A3CC00DA1D35 /* AddFolderSheet.xib in Resources */,
+				5144EA52227B8E4500D19003 /* AccountsFeedbin.xib in Resources */,
+				8405DDA222168920008CE1BF /* TimelineTableView.xib in Resources */,
+				B528F81E23333C7E00E735DD /* page.html in Resources */,
+				8483630E2262A3FE00DA1D35 /* MainWindow.storyboard in Resources */,
+				55E15BCB229D65A900D6602A /* AccountsReaderAPI.xib in Resources */,
+				49F40DF82335B71000552BF4 /* newsfoot.js in Resources */,
+				84BAE64921CEDAF20046DB56 /* CrashReporterWindow.xib in Resources */,
+				84C9FC8E22629E8F00D921D6 /* Credits.rtf in Resources */,
+				84BBB12D20142A4700F054F5 /* Inspector.storyboard in Resources */,
+				848363022262A3BD00DA1D35 /* AddFeedSheet.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C646F1ED37A5D003D8FC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		515D50802326D02600EE1167 /* Run Script: Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Verify No Build Settings";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "xcrun -sdk macosx swiftc -target x86_64-macosx10.11  buildscripts/VerifyNoBuildSettings.swift -o $CONFIGURATION_TEMP_DIR/VerifyNoBS\n$CONFIGURATION_TEMP_DIR/VerifyNoBS ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+		};
+		517D2D80233A46ED00FF3E35 /* Run Script: Update ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Update ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FAILED=false\n\nif [ -z \"${MERCURY_CLIENT_ID}\" ]; then\nFAILED=true\nfi\n\nif [ -z \"${MERCURY_CLIENT_SECRET}\" ]; then\nFAILED=true\nfi\n\nif [ \"$FAILED\" = true ]; then\necho \"Missing Feedbin Mercury credetials.  ArticleExtractorConfig.swift not changed.\"\nexit 0\nfi\n\nsed -i .tmp \"s|{MERCURYID}|${MERCURY_CLIENT_ID}|g; s|{MERCURYSECRET}|${MERCURY_CLIENT_SECRET}|g\" \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n\nrm -f \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift.tmp\"\n\necho \"All env values found!\"\n";
+		};
+		517D2D81233A47AD00FF3E35 /* Run Script: Reset ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Reset ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git checkout \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n";
+		};
+		517D2D82233A53D600FF3E35 /* Run Script: Reset ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Reset ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git checkout \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n";
+		};
+		51D6803823330CFF0097A009 /* Run Script: Update ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Update ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FAILED=false\n\nif [ -z \"${MERCURY_CLIENT_ID}\" ]; then\nFAILED=true\nfi\n\nif [ -z \"${MERCURY_CLIENT_SECRET}\" ]; then\nFAILED=true\nfi\n\nif [ \"$FAILED\" = true ]; then\necho \"Missing Feedbin Mercury credetials.  ArticleExtractorConfig.swift not changed.\"\nexit 0\nfi\n\nsed -i .tmp \"s|{MERCURYID}|${MERCURY_CLIENT_ID}|g; s|{MERCURYSECRET}|${MERCURY_CLIENT_SECRET}|g\" \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n\nrm -f \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift.tmp\"\n\necho \"All env values found!\"\n\n";
+		};
+		65ED3FB5235DEF6C0081F399 /* Run Script: Update ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Update ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FAILED=false\n\nif [ -z \"${MERCURY_CLIENT_ID}\" ]; then\nFAILED=true\nfi\n\nif [ -z \"${MERCURY_CLIENT_SECRET}\" ]; then\nFAILED=true\nfi\n\nif [ \"$FAILED\" = true ]; then\necho \"Missing Feedbin Mercury credetials.  ArticleExtractorConfig.swift not changed.\"\nexit 0\nfi\n\nsed -i .tmp \"s|{MERCURYID}|${MERCURY_CLIENT_ID}|g; s|{MERCURYSECRET}|${MERCURY_CLIENT_SECRET}|g\" \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n\nrm -f \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift.tmp\"\n\necho \"All env values found!\"\n\n";
+		};
+		65ED4041235DEF6C0081F399 /* Run Script: Reset ArticleExtractorConfig.swift */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Reset ArticleExtractorConfig.swift";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git checkout \"${SRCROOT}/Shared/Article Extractor/ArticleExtractorConfig.swift\"\n";
+		};
+		65ED406F235DEF6C0081F399 /* Run Script: Automated build numbers */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Automated build numbers";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# See https://blog.curtisherbert.com/automated-build-numbers/\n\n# WARNING: If automated build numbers are restored then take \n# care to ensure any app extensions are versioned the same as the app.\n# ask Daniel (jalkut@red-sweater.com) if in doubt about this. \n#git=`sh /etc/profile; which git`\n#branch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\n#git_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n#simple_branch_name=`$git rev-parse --abbrev-ref HEAD`\n\n#build_number=\"$git_count\"\n#if [ $CONFIGURATION != \"Release\" ]; then\n#build_number+=\"-$simple_branch_name\"\n#fi\n\n#plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n#dsym_plist=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n#/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$plist\"\n#if [ -f \"$DSYM_INFO_PLIST\" ] ; then\n#/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$dsym_plist\"\n#fi\n";
+		};
+		65ED407D235DEF6C0081F399 /* Run Script: Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Verify No Build Settings";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "xcrun -sdk macosx swiftc -target x86_64-macosx10.11  buildscripts/VerifyNoBuildSettings.swift -o $CONFIGURATION_TEMP_DIR/VerifyNoBS\n$CONFIGURATION_TEMP_DIR/VerifyNoBS ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+		};
+		8423E3E3220158E700C3795B /* Run Script: Code Sign Sparkle */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Code Sign Sparkle";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Remove unused Sparkle components\nSPARKLE_DIR=\"${CODESIGNING_FOLDER_PATH}/Contents/Frameworks/Sparkle.framework\"\nfind \"${SPARKLE_DIR}\" -name Updater.app -execdir rm -rf {} \\;\nfind \"${SPARKLE_DIR}\" -name Autoupdate -execdir rm -rf {} \\;\n\n# Sign XPC Helpers and their internal binaries\ncodesign --verbose --force -o runtime --preserve-metadata=entitlements --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Updater.app\"\ncodesign --verbose --force -o runtime --preserve-metadata=entitlements --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Autoupdate\"\ncodesign --verbose --entitlements \"${PROJECT_DIR}/submodules/Sparkle/Downloader/org.sparkle-project.Downloader.entitlements\" --force -o runtime --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.Downloader.xpc\"\ncodesign --verbose --force -o runtime --preserve-metadata=entitlements --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.InstallerLauncher.xpc\"\ncodesign --verbose --force -o runtime --preserve-metadata=entitlements --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.InstallerConnection.xpc\"\ncodesign --verbose --force -o runtime --preserve-metadata=entitlements --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${CODESIGNING_FOLDER_PATH}/Contents/XPCServices/org.sparkle-project.InstallerStatus.xpc\"\n";
+		};
+		84C987A52000AC9E0066B150 /* Run Script: Automated build numbers */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Automated build numbers";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# See https://blog.curtisherbert.com/automated-build-numbers/\n\n# WARNING: If automated build numbers are restored then take \n# care to ensure any app extensions are versioned the same as the app.\n# ask Daniel (jalkut@red-sweater.com) if in doubt about this. \n#git=`sh /etc/profile; which git`\n#branch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\n#git_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n#simple_branch_name=`$git rev-parse --abbrev-ref HEAD`\n\n#build_number=\"$git_count\"\n#if [ $CONFIGURATION != \"Release\" ]; then\n#build_number+=\"-$simple_branch_name\"\n#fi\n\n#plist=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n#dsym_plist=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n#/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$plist\"\n#if [ -f \"$DSYM_INFO_PLIST\" ] ; then\n#/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"$dsym_plist\"\n#fi\n";
+		};
+		D519E77022EE5B4100923F27 /* Run Script: Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Verify No Build Settings";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "xcrun -sdk macosx swiftc -target x86_64-macosx10.11  buildscripts/VerifyNoBuildSettings.swift -o $CONFIGURATION_TEMP_DIR/VerifyNoBS\n$CONFIGURATION_TEMP_DIR/VerifyNoBS ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		51314633235A7BBE00387FDC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				513146B3235A81A400387FDC /* AddFeedIntentHandler.swift in Sources */,
+				51314705235C41FC00387FDC /* Intents.intentdefinition in Sources */,
+				51314668235A7E4600387FDC /* IntentHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		513C5CE2232571C2003D4054 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				515D4FC123257A3200EE1167 /* FolderTreeControllerDelegate.swift in Sources */,
+				515D4FCA23257CB500EE1167 /* Node-Extensions.swift in Sources */,
+				513C5CE9232571C2003D4054 /* ShareViewController.swift in Sources */,
+				5170743A232AABFC00A461A3 /* FlattenedAccountFolderPickerData.swift in Sources */,
+				51707439232AA97100A461A3 /* ShareFolderPickerController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		518B2ECE2351B3DD00400001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				518B2EE82351B45600400001 /* NetNewsWire_iOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6581C72F20CED60000F4AD34 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6581C73A20CED60100F4AD34 /* SafariExtensionViewController.swift in Sources */,
+				6581C73820CED60100F4AD34 /* SafariExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED3FB6235DEF6C0081F399 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED3FB7235DEF6C0081F399 /* ArticleArray.swift in Sources */,
+				65ED3FB8235DEF6C0081F399 /* CrashReporter.swift in Sources */,
+				65ED3FB9235DEF6C0081F399 /* TimelineAvatarView.swift in Sources */,
+				65ED3FBA235DEF6C0081F399 /* ArticleExtractorConfig.swift in Sources */,
+				65ED3FBB235DEF6C0081F399 /* InspectorWindowController.swift in Sources */,
+				65ED3FBC235DEF6C0081F399 /* ColorHash.swift in Sources */,
+				65ED3FBD235DEF6C0081F399 /* AppDefaults.swift in Sources */,
+				65ED3FBE235DEF6C0081F399 /* Account+Scriptability.swift in Sources */,
+				65ED3FBF235DEF6C0081F399 /* NothingInspectorViewController.swift in Sources */,
+				65ED3FC0235DEF6C0081F399 /* AppNotifications.swift in Sources */,
+				65ED3FC1235DEF6C0081F399 /* TimelineKeyboardDelegate.swift in Sources */,
+				65ED3FC2235DEF6C0081F399 /* Browser.swift in Sources */,
+				65ED3FC3235DEF6C0081F399 /* DetailWebViewController.swift in Sources */,
+				65ED3FC4235DEF6C0081F399 /* OPMLExporter.swift in Sources */,
+				65ED3FC5235DEF6C0081F399 /* MainWindowController.swift in Sources */,
+				65ED3FC6235DEF6C0081F399 /* UnreadFeed.swift in Sources */,
+				65ED3FC7235DEF6C0081F399 /* Reachability.swift in Sources */,
+				65ED3FC8235DEF6C0081F399 /* SidebarCellLayout.swift in Sources */,
+				65ED3FC9235DEF6C0081F399 /* SmartFeedPasteboardWriter.swift in Sources */,
+				65ED3FCA235DEF6C0081F399 /* SmartFeedsController.swift in Sources */,
+				65ED3FCB235DEF6C0081F399 /* SidebarViewController.swift in Sources */,
+				65ED3FCC235DEF6C0081F399 /* AccountsFeedlyWebWindowController.swift in Sources */,
+				65ED3FCD235DEF6C0081F399 /* SidebarOutlineView.swift in Sources */,
+				65ED3FCE235DEF6C0081F399 /* DetailKeyboardDelegate.swift in Sources */,
+				65ED3FCF235DEF6C0081F399 /* TimelineContainerView.swift in Sources */,
+				65ED3FD0235DEF6C0081F399 /* Author+Scriptability.swift in Sources */,
+				65ED3FD1235DEF6C0081F399 /* PseudoFeed.swift in Sources */,
+				65ED3FD2235DEF6C0081F399 /* AccountsAddViewController.swift in Sources */,
+				65ED3FD3235DEF6C0081F399 /* NSScriptCommand+NetNewsWire.swift in Sources */,
+				65ED3FD4235DEF6C0081F399 /* Article+Scriptability.swift in Sources */,
+				65ED3FD5235DEF6C0081F399 /* SmartFeed.swift in Sources */,
+				65ED3FD6235DEF6C0081F399 /* MarkStatusCommand.swift in Sources */,
+				65ED3FD7235DEF6C0081F399 /* NSApplication+Scriptability.swift in Sources */,
+				65ED3FD8235DEF6C0081F399 /* NSView-Extensions.swift in Sources */,
+				65ED3FD9235DEF6C0081F399 /* SidebarCell.swift in Sources */,
+				65ED3FDA235DEF6C0081F399 /* ArticleStatusSyncTimer.swift in Sources */,
+				65ED3FDB235DEF6C0081F399 /* FeedTreeControllerDelegate.swift in Sources */,
+				65ED3FDC235DEF6C0081F399 /* UnreadCountView.swift in Sources */,
+				65ED3FDD235DEF6C0081F399 /* ActivityType.swift in Sources */,
+				65ED3FDE235DEF6C0081F399 /* CrashReportWindowController.swift in Sources */,
+				65ED3FDF235DEF6C0081F399 /* FeedIconDownloader.swift in Sources */,
+				65ED3FE0235DEF6C0081F399 /* AccountsControlsBackgroundView.swift in Sources */,
+				65ED3FE1235DEF6C0081F399 /* MarkCommandValidationStatus.swift in Sources */,
+				65ED3FE2235DEF6C0081F399 /* ArticlePasteboardWriter.swift in Sources */,
+				65ED3FE3235DEF6C0081F399 /* ArticleUtilities.swift in Sources */,
+				65ED3FE4235DEF6C0081F399 /* NNW3OpenPanelAccessoryViewController.swift in Sources */,
+				65ED3FE5235DEF6C0081F399 /* DefaultFeedsImporter.swift in Sources */,
+				65ED3FE6235DEF6C0081F399 /* RenameWindowController.swift in Sources */,
+				65ED3FE7235DEF6C0081F399 /* SendToMicroBlogCommand.swift in Sources */,
+				65ED3FE8235DEF6C0081F399 /* ArticleStyle.swift in Sources */,
+				65ED3FE9235DEF6C0081F399 /* FaviconURLFinder.swift in Sources */,
+				65ED3FEA235DEF6C0081F399 /* SidebarViewController+ContextualMenus.swift in Sources */,
+				65ED3FEB235DEF6C0081F399 /* (null) in Sources */,
+				65ED3FEC235DEF6C0081F399 /* RSHTMLMetadata+Extension.swift in Sources */,
+				65ED3FED235DEF6C0081F399 /* SendToMarsEditCommand.swift in Sources */,
+				65ED3FEE235DEF6C0081F399 /* UserNotificationManager.swift in Sources */,
+				65ED3FEF235DEF6C0081F399 /* ScriptingObjectContainer.swift in Sources */,
+				65ED3FF0235DEF6C0081F399 /* ArticleStylesManager.swift in Sources */,
+				65ED3FF1235DEF6C0081F399 /* DetailContainerView.swift in Sources */,
+				65ED3FF2235DEF6C0081F399 /* SharingServiceDelegate.swift in Sources */,
+				65ED3FF3235DEF6C0081F399 /* ArticleSorter.swift in Sources */,
+				65ED3FF4235DEF6C0081F399 /* TimelineViewController+ContextualMenus.swift in Sources */,
+				65ED3FF5235DEF6C0081F399 /* ArticleStringFormatter.swift in Sources */,
+				65ED3FF6235DEF6C0081F399 /* MultilineTextFieldSizer.swift in Sources */,
+				65ED3FF7235DEF6C0081F399 /* SearchFeedDelegate.swift in Sources */,
+				65ED3FF8235DEF6C0081F399 /* ErrorHandler.swift in Sources */,
+				65ED3FF9235DEF6C0081F399 /* ActivityManager.swift in Sources */,
+				65ED3FFA235DEF6C0081F399 /* FeedInspectorViewController.swift in Sources */,
+				65ED3FFB235DEF6C0081F399 /* AccountsReaderAPIWindowController.swift in Sources */,
+				65ED3FFC235DEF6C0081F399 /* AccountsAddLocalWindowController.swift in Sources */,
+				65ED3FFD235DEF6C0081F399 /* PasteboardFolder.swift in Sources */,
+				65ED3FFE235DEF6C0081F399 /* AccountsFeedbinWindowController.swift in Sources */,
+				65ED3FFF235DEF6C0081F399 /* SidebarOutlineDataSource.swift in Sources */,
+				65ED4000235DEF6C0081F399 /* SidebarCellAppearance.swift in Sources */,
+				65ED4001235DEF6C0081F399 /* StarredFeedDelegate.swift in Sources */,
+				65ED4002235DEF6C0081F399 /* FaviconDownloader.swift in Sources */,
+				65ED4003235DEF6C0081F399 /* AdvancedPreferencesViewController.swift in Sources */,
+				65ED4004235DEF6C0081F399 /* SharingServicePickerDelegate.swift in Sources */,
+				65ED4005235DEF6C0081F399 /* Node-Extensions.swift in Sources */,
+				65ED4006235DEF6C0081F399 /* AppAssets.swift in Sources */,
+				65ED4007235DEF6C0081F399 /* AddFeedController.swift in Sources */,
+				65ED4008235DEF6C0081F399 /* AccountRefreshTimer.swift in Sources */,
+				65ED4009235DEF6C0081F399 /* SidebarStatusBarView.swift in Sources */,
+				65ED400A235DEF6C0081F399 /* SearchTimelineFeedDelegate.swift in Sources */,
+				65ED400B235DEF6C0081F399 /* TodayFeedDelegate.swift in Sources */,
+				65ED400C235DEF6C0081F399 /* FolderInspectorViewController.swift in Sources */,
+				65ED400D235DEF6C0081F399 /* SmartFeedDelegate.swift in Sources */,
+				65ED400E235DEF6C0081F399 /* ImageDownloader.swift in Sources */,
+				65ED400F235DEF6C0081F399 /* ArticleExtractorButton.swift in Sources */,
+				65ED4010235DEF6C0081F399 /* AccountsAddTableCellView.swift in Sources */,
+				65ED4011235DEF6C0081F399 /* AddFolderWindowController.swift in Sources */,
+				65ED4012235DEF6C0081F399 /* TimelineContainerViewController.swift in Sources */,
+				65ED4013235DEF6C0081F399 /* MainWIndowKeyboardHandler.swift in Sources */,
+				65ED4014235DEF6C0081F399 /* PasteboardFeed.swift in Sources */,
+				65ED4015235DEF6C0081F399 /* AccountsDetailViewController.swift in Sources */,
+				65ED4016235DEF6C0081F399 /* DetailViewController.swift in Sources */,
+				65ED4017235DEF6C0081F399 /* AppDelegate.swift in Sources */,
+				65ED4018235DEF6C0081F399 /* AccountsTableViewBackgroundView.swift in Sources */,
+				65ED4019235DEF6C0081F399 /* FetchRequestOperation.swift in Sources */,
+				65ED401A235DEF6C0081F399 /* HTMLMetadataDownloader.swift in Sources */,
+				65ED401B235DEF6C0081F399 /* TimelineViewController.swift in Sources */,
+				65ED401C235DEF6C0081F399 /* FaviconGenerator.swift in Sources */,
+				65ED401D235DEF6C0081F399 /* RefreshInterval.swift in Sources */,
+				65ED401E235DEF6C0081F399 /* TimelineCellData.swift in Sources */,
+				65ED401F235DEF6C0081F399 /* BuiltinSmartFeedInspectorViewController.swift in Sources */,
+				65ED4020235DEF6C0081F399 /* AppDelegate+Scriptability.swift in Sources */,
+				65ED4021235DEF6C0081F399 /* NNW3Document.swift in Sources */,
+				65ED4022235DEF6C0081F399 /* ScriptingObject.swift in Sources */,
+				65ED4023235DEF6C0081F399 /* Folder+Scriptability.swift in Sources */,
+				65ED4024235DEF6C0081F399 /* TimelineCellLayout.swift in Sources */,
+				65ED4025235DEF6C0081F399 /* DetailWebView.swift in Sources */,
+				65ED4026235DEF6C0081F399 /* TimelineTableRowView.swift in Sources */,
+				65ED4027235DEF6C0081F399 /* UnreadIndicatorView.swift in Sources */,
+				65ED4028235DEF6C0081F399 /* ExtractedArticle.swift in Sources */,
+				65ED4029235DEF6C0081F399 /* DeleteCommand.swift in Sources */,
+				65ED402A235DEF6C0081F399 /* AddFeedWindowController.swift in Sources */,
+				65ED402B235DEF6C0081F399 /* ImportOPMLWindowController.swift in Sources */,
+				65ED402C235DEF6C0081F399 /* TimelineTableView.swift in Sources */,
+				65ED402D235DEF6C0081F399 /* DetailStatusBarView.swift in Sources */,
+				65ED402E235DEF6C0081F399 /* MainWindowController+Scriptability.swift in Sources */,
+				65ED402F235DEF6C0081F399 /* PreferencesWindowController.swift in Sources */,
+				65ED4030235DEF6C0081F399 /* SmallIconProvider.swift in Sources */,
+				65ED4031235DEF6C0081F399 /* ArticleExtractor.swift in Sources */,
+				65ED4032235DEF6C0081F399 /* FetchRequestQueue.swift in Sources */,
+				65ED4033235DEF6C0081F399 /* SidebarKeyboardDelegate.swift in Sources */,
+				65ED4034235DEF6C0081F399 /* AccountsPreferencesViewController.swift in Sources */,
+				65ED4035235DEF6C0081F399 /* FolderTreeMenu.swift in Sources */,
+				65ED4036235DEF6C0081F399 /* NNW3ImportController.swift in Sources */,
+				65ED4037235DEF6C0081F399 /* FolderTreeControllerDelegate.swift in Sources */,
+				65ED4038235DEF6C0081F399 /* RSImage-Extensions.swift in Sources */,
+				65ED4039235DEF6C0081F399 /* SingleFaviconDownloader.swift in Sources */,
+				65ED403A235DEF6C0081F399 /* Feed+Scriptability.swift in Sources */,
+				65ED403B235DEF6C0081F399 /* AuthorAvatarDownloader.swift in Sources */,
+				65ED403C235DEF6C0081F399 /* SingleLineTextFieldSizer.swift in Sources */,
+				65ED403D235DEF6C0081F399 /* TimelineTableCellView.swift in Sources */,
+				65ED403E235DEF6C0081F399 /* TimelineCellAppearance.swift in Sources */,
+				65ED403F235DEF6C0081F399 /* ArticleRenderer.swift in Sources */,
+				65ED4040235DEF6C0081F399 /* GeneralPrefencesViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65ED4091235DEF770081F399 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65ED4092235DEF770081F399 /* SafariExtensionViewController.swift in Sources */,
+				65ED4093235DEF770081F399 /* SafariExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		840D61782029031C009BC708 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				840D617F2029031C009BC708 /* AppDelegate.swift in Sources */,
+				51236339236915B100951F16 /* RoundedProgressView.swift in Sources */,
+				512E08E72268801200BDCFDD /* FeedTreeControllerDelegate.swift in Sources */,
+				51C452A422650A2D00C03939 /* ArticleUtilities.swift in Sources */,
+				51EF0F79227716380050506E /* ColorHash.swift in Sources */,
+				5183CCDA226E31A50010922C /* NonIntrinsicImageView.swift in Sources */,
+				51EAED96231363EF00A9EEE3 /* NonIntrinsicButton.swift in Sources */,
+				51C4527B2265091600C03939 /* MasterUnreadIndicatorView.swift in Sources */,
+				5186A635235EF3A800C97195 /* VibrantLabel.swift in Sources */,
+				51F85BF92274AA7B00C787DC /* UIBarButtonItem-Extensions.swift in Sources */,
+				51B62E68233186730085F949 /* AvatarView.swift in Sources */,
+				51C45296226509D300C03939 /* OPMLExporter.swift in Sources */,
+				51C45291226509C800C03939 /* SmartFeed.swift in Sources */,
+				51C452A722650A3D00C03939 /* RSImage-Extensions.swift in Sources */,
+				51C45269226508F600C03939 /* MasterFeedTableViewCell.swift in Sources */,
+				51F85BFD2275DCA800C787DC /* SingleLineUILabelSizer.swift in Sources */,
+				517630232336657E00E15FFF /* ArticleViewControllerWebViewProvider.swift in Sources */,
+				51C4528F226509BD00C03939 /* UnreadFeed.swift in Sources */,
+				51AF460E232488C6001742EF /* Account-Extensions.swift in Sources */,
+				51FD413B2342BD0500880194 /* MasterTimelineUnreadCountView.swift in Sources */,
+				513146B2235A81A400387FDC /* AddFeedIntentHandler.swift in Sources */,
+				51D87EE12311D34700E63F03 /* ActivityType.swift in Sources */,
+				51C452772265091600C03939 /* MultilineUILabelSizer.swift in Sources */,
+				51C452A522650A2D00C03939 /* SmallIconProvider.swift in Sources */,
+				516A09392360A2AE00EAE89B /* SettingsAccountTableViewCell.swift in Sources */,
+				51D5948722668EFA00DFC836 /* MarkStatusCommand.swift in Sources */,
+				51A1699C235E10D700EB091F /* AddAccountViewController.swift in Sources */,
+				51A16999235E10D700EB091F /* LocalAccountViewController.swift in Sources */,
+				514B7C8323205EFB00BAC947 /* RootSplitViewController.swift in Sources */,
+				51FA73A52332BE110090D516 /* ArticleExtractor.swift in Sources */,
+				51314704235C41FC00387FDC /* Intents.intentdefinition in Sources */,
+				FF3ABF162325AF5D0074C542 /* ArticleSorter.swift in Sources */,
+				51C4525C226508DF00C03939 /* String-Extensions.swift in Sources */,
+				51C452792265091600C03939 /* MasterTimelineTableViewCell.swift in Sources */,
+				51FA73AB2332C2FD0090D516 /* ArticleExtractorConfig.swift in Sources */,
+				51C452852265093600C03939 /* FlattenedAccountFolderPickerData.swift in Sources */,
+				51C4526B226508F600C03939 /* MasterFeedViewController.swift in Sources */,
+				5126EE97226CB48A00C22AFC /* SceneCoordinator.swift in Sources */,
+				51FD40C72341555A00880194 /* UIImage-Extensions.swift in Sources */,
+				84CAFCB022BC8C35007694F0 /* FetchRequestOperation.swift in Sources */,
+				51EF0F77227716200050506E /* FaviconGenerator.swift in Sources */,
+				51938DF3231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift in Sources */,
+				51C4525A226508D600C03939 /* UIStoryboard-Extensions.swift in Sources */,
+				51BB7C272335A8E5008E8144 /* ArticleActivityItemSource.swift in Sources */,
+				51F85BF52273625800C787DC /* Bundle-Extensions.swift in Sources */,
+				51C452A622650A3500C03939 /* Node-Extensions.swift in Sources */,
+				51C45294226509C800C03939 /* SearchFeedDelegate.swift in Sources */,
+				5F323809231DF9F000706F6B /* VibrantTableViewCell.swift in Sources */,
+				512E09352268B25900BDCFDD /* UISplitViewController-Extensions.swift in Sources */,
+				51FE10042345529D0056195D /* UserNotificationManager.swift in Sources */,
+				51C452A022650A1900C03939 /* FeedIconDownloader.swift in Sources */,
+				51C4529E22650A1900C03939 /* ImageDownloader.swift in Sources */,
+				51C45292226509C800C03939 /* TodayFeedDelegate.swift in Sources */,
+				51C452A222650A1900C03939 /* RSHTMLMetadata+Extension.swift in Sources */,
+				514B7D1F23219F3C00BAC947 /* AddControllerType.swift in Sources */,
+				51E3EB3D229AB08300645299 /* ErrorHandler.swift in Sources */,
+				5183CCE5226F4DFA0010922C /* RefreshInterval.swift in Sources */,
+				51C4529D22650A1000C03939 /* FaviconURLFinder.swift in Sources */,
+				5142192A23522B5500E07E2C /* ImageViewController.swift in Sources */,
+				51C45258226508CF00C03939 /* AppAssets.swift in Sources */,
+				51FA73A82332BE880090D516 /* ExtractedArticle.swift in Sources */,
+				51C4527C2265091600C03939 /* MasterTimelineDefaultCellLayout.swift in Sources */,
+				51C4529A22650A0400C03939 /* ArticleStyle.swift in Sources */,
+				51C4527F2265092C00C03939 /* ArticleViewController.swift in Sources */,
+				51C4526A226508F600C03939 /* MasterFeedTableViewCellLayout.swift in Sources */,
+				51C452AE2265104D00C03939 /* ArticleStringFormatter.swift in Sources */,
+				512E08E62268800D00BDCFDD /* FolderTreeControllerDelegate.swift in Sources */,
+				51C4529922650A0000C03939 /* ArticleStylesManager.swift in Sources */,
+				5123DB9F233EC6FD00282CC9 /* FeedInspectorView.swift in Sources */,
+				51EF0F802277A8330050506E /* MasterTimelineCellLayout.swift in Sources */,
+				51F85BF722749FA100C787DC /* UIFont-Extensions.swift in Sources */,
+				51C452AF2265108300C03939 /* ArticleArray.swift in Sources */,
+				51C4528E2265099C00C03939 /* SmartFeedsController.swift in Sources */,
+				51102165233A7D6C0007A5F7 /* ArticleExtractorButton.swift in Sources */,
+				84CAFCA522BC8C08007694F0 /* FetchRequestQueue.swift in Sources */,
+				51C4529C22650A1000C03939 /* SingleFaviconDownloader.swift in Sources */,
+				51E595A6228CC36500FCC42B /* ArticleStatusSyncTimer.swift in Sources */,
+				51A1699F235E10D700EB091F /* AboutViewController.swift in Sources */,
+				51C45290226509C100C03939 /* PseudoFeed.swift in Sources */,
+				51C452A922650DC600C03939 /* ArticleRenderer.swift in Sources */,
+				5115CAF42266301400B21BCE /* AddContainerViewController.swift in Sources */,
+				51C45297226509E300C03939 /* DefaultFeedsImporter.swift in Sources */,
+				512E094D2268B8AB00BDCFDD /* DeleteCommand.swift in Sources */,
+				51F85BFB2275D85000C787DC /* Array-Extensions.swift in Sources */,
+				51C452AC22650FD200C03939 /* AppNotifications.swift in Sources */,
+				51EF0F7E2277A57D0050506E /* MasterTimelineAccessibilityCellLayout.swift in Sources */,
+				51A1699B235E10D700EB091F /* AccountInspectorViewController.swift in Sources */,
+				51C452762265091600C03939 /* MasterTimelineViewController.swift in Sources */,
+				5183CCE9226F68D90010922C /* AccountRefreshTimer.swift in Sources */,
+				51C452882265093600C03939 /* AddFeedViewController.swift in Sources */,
+				51A169A0235E10D700EB091F /* FeedbinAccountViewController.swift in Sources */,
+				51934CCE2310792F006127BE /* ActivityManager.swift in Sources */,
+				518651DA235621840078E021 /* ImageTransition.swift in Sources */,
+				514219372352510100E07E2C /* ImageScrollView.swift in Sources */,
+				51A16997235E10D700EB091F /* RefreshIntervalViewController.swift in Sources */,
+				51C4529B22650A1000C03939 /* FaviconDownloader.swift in Sources */,
+				84DEE56622C32CA4005FC42C /* SmartFeedDelegate.swift in Sources */,
+				512E09012268907400BDCFDD /* MasterFeedTableViewSectionHeader.swift in Sources */,
+				519D740623243CC0008BB345 /* RefreshInterval-Extensions.swift in Sources */,
+				51C45268226508F600C03939 /* MasterFeedUnreadCountView.swift in Sources */,
+				5183CCD0226E1E880010922C /* NonIntrinsicLabel.swift in Sources */,
+				51C4529F22650A1900C03939 /* AuthorAvatarDownloader.swift in Sources */,
+				519E743D22C663F900A78E47 /* SceneDelegate.swift in Sources */,
+				51CC9B3E231720B2000E842F /* MasterFeedDataSource.swift in Sources */,
+				FFD43E412340F488009E5CA3 /* UndoAvailableAlertController.swift in Sources */,
+				51C452A322650A1E00C03939 /* HTMLMetadataDownloader.swift in Sources */,
+				51C4528D2265095F00C03939 /* AddFolderViewController.swift in Sources */,
+				51C452782265091600C03939 /* MasterTimelineCellData.swift in Sources */,
+				5148F4552336DB7000F8CD8B /* MasterTimelineTitleView.swift in Sources */,
+				51FFF0C4235EE8E5002762AA /* VibrantButton.swift in Sources */,
+				513228FC233037630033D4ED /* Reachability.swift in Sources */,
+				51C45259226508D300C03939 /* AppDefaults.swift in Sources */,
+				51CE1C0B23622007005548FC /* RefreshProgressView.swift in Sources */,
+				511D4419231FC02D00FB1562 /* KeyboardManager.swift in Sources */,
+				51A1699D235E10D700EB091F /* SettingsViewController.swift in Sources */,
+				51C45293226509C800C03939 /* StarredFeedDelegate.swift in Sources */,
+				51D6A5BC23199C85001C27D8 /* MasterTimelineDataSource.swift in Sources */,
+				51934CCB230F599B006127BE /* ThemedNavigationController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C645C1ED37A5D003D8FC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84F204E01FAACBB30076E152 /* ArticleArray.swift in Sources */,
+				848B937221C8C5540038DC0D /* CrashReporter.swift in Sources */,
+				847CD6CA232F4CBF00FAC46D /* TimelineAvatarView.swift in Sources */,
+				51FA73AA2332C2FD0090D516 /* ArticleExtractorConfig.swift in Sources */,
+				84BBB12E20142A4700F054F5 /* InspectorWindowController.swift in Sources */,
+				51EF0F7A22771B890050506E /* ColorHash.swift in Sources */,
+				84E46C7D1F75EF7B005ECFB3 /* AppDefaults.swift in Sources */,
+				D5907D972004B7EB005947E5 /* Account+Scriptability.swift in Sources */,
+				841ABA4E20145E7300980E11 /* NothingInspectorViewController.swift in Sources */,
+				842E45CE1ED8C308000A8B52 /* AppNotifications.swift in Sources */,
+				844B5B5B1FEA00FB00C7C76A /* TimelineKeyboardDelegate.swift in Sources */,
+				842E45DD1ED8C54B000A8B52 /* Browser.swift in Sources */,
+				84216D0322128B9D0049B9B9 /* DetailWebViewController.swift in Sources */,
+				8444C8F21FED81840051386C /* OPMLExporter.swift in Sources */,
+				849A975E1ED9EB72007D329B /* MainWindowController.swift in Sources */,
+				84F2D53A1FC2308B00998D64 /* UnreadFeed.swift in Sources */,
+				513228FB233037630033D4ED /* Reachability.swift in Sources */,
+				845A29221FC9251E007B49E3 /* SidebarCellLayout.swift in Sources */,
+				84AD1EBA2031649C00BC20B7 /* SmartFeedPasteboardWriter.swift in Sources */,
+				849C78922362AB04009A71E4 /* ExportOPMLWindowController.swift in Sources */,
+				84CC88181FE59CBF00644329 /* SmartFeedsController.swift in Sources */,
+				849A97661ED9EB96007D329B /* SidebarViewController.swift in Sources */,
+				9EA33BB92318F8C10097B644 /* AccountsFeedlyWebWindowController.swift in Sources */,
+				849A97641ED9EB96007D329B /* SidebarOutlineView.swift in Sources */,
+				5127B238222B4849006D641D /* DetailKeyboardDelegate.swift in Sources */,
+				8405DD9922153B6B008CE1BF /* TimelineContainerView.swift in Sources */,
+				D5A2678C20130ECF00A8D3C0 /* Author+Scriptability.swift in Sources */,
+				84F2D5371FC22FCC00998D64 /* PseudoFeed.swift in Sources */,
+				51EF0F902279C9500050506E /* AccountsAddViewController.swift in Sources */,
+				D57BE6E0204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift in Sources */,
+				D553738B20186C20006D8857 /* Article+Scriptability.swift in Sources */,
+				845EE7C11FC2488C00854A1F /* SmartFeed.swift in Sources */,
+				84702AA41FA27AC0006B8943 /* MarkStatusCommand.swift in Sources */,
+				D5907D7F2004AC00005947E5 /* NSApplication+Scriptability.swift in Sources */,
+				8405DD9C22153BD7008CE1BF /* NSView-Extensions.swift in Sources */,
+				849A979F1ED9F130007D329B /* SidebarCell.swift in Sources */,
+				51E595A5228CC36500FCC42B /* ArticleStatusSyncTimer.swift in Sources */,
+				849A97651ED9EB96007D329B /* FeedTreeControllerDelegate.swift in Sources */,
+				849A97671ED9EB96007D329B /* UnreadCountView.swift in Sources */,
+				51FE10092346739D0056195D /* ActivityType.swift in Sources */,
+				840BEE4121D70E64009BBAFA /* CrashReportWindowController.swift in Sources */,
+				8426118A1FCB67AA0086A189 /* FeedIconDownloader.swift in Sources */,
+				84C9FC7B22629E1200D921D6 /* AccountsControlsBackgroundView.swift in Sources */,
+				84162A152038C12C00035290 /* MarkCommandValidationStatus.swift in Sources */,
+				84E95D241FB1087500552D99 /* ArticlePasteboardWriter.swift in Sources */,
+				849A975B1ED9EB0D007D329B /* ArticleUtilities.swift in Sources */,
+				849ADEE8235981A0000E1B81 /* NNW3OpenPanelAccessoryViewController.swift in Sources */,
+				849A975C1ED9EB0D007D329B /* DefaultFeedsImporter.swift in Sources */,
+				84A37CB5201ECD610087C5AF /* RenameWindowController.swift in Sources */,
+				84A14FF320048CA70046AD9A /* SendToMicroBlogCommand.swift in Sources */,
+				849A97891ED9ECEF007D329B /* ArticleStyle.swift in Sources */,
+				84FF69B11FC3793300DC198E /* FaviconURLFinder.swift in Sources */,
+				84B7178C201E66580091657D /* SidebarViewController+ContextualMenus.swift in Sources */,
+				842611A21FCB769D0086A189 /* RSHTMLMetadata+Extension.swift in Sources */,
+				84A1500520048DDF0046AD9A /* SendToMarsEditCommand.swift in Sources */,
+				51FE10032345529D0056195D /* UserNotificationManager.swift in Sources */,
+				D5907DB22004BB37005947E5 /* ScriptingObjectContainer.swift in Sources */,
+				849A978A1ED9ECEF007D329B /* ArticleStylesManager.swift in Sources */,
+				8405DD8A2213E0E3008CE1BF /* DetailContainerView.swift in Sources */,
+				519B8D332143397200FA689C /* SharingServiceDelegate.swift in Sources */,
+				FF3ABF1523259DDB0074C542 /* ArticleSorter.swift in Sources */,
+				84E8E0DB202EC49300562D8F /* TimelineViewController+ContextualMenus.swift in Sources */,
+				849A97791ED9EC04007D329B /* ArticleStringFormatter.swift in Sources */,
+				84E185C3203BB12600F69BFA /* MultilineTextFieldSizer.swift in Sources */,
+				8477ACBE22238E9500DF7F37 /* SearchFeedDelegate.swift in Sources */,
+				51E3EB33229AB02C00645299 /* ErrorHandler.swift in Sources */,
+				51FE100A234673A00056195D /* ActivityManager.swift in Sources */,
+				8472058120142E8900AD578B /* FeedInspectorViewController.swift in Sources */,
+				55E15BCC229D65A900D6602A /* AccountsReaderAPIWindowController.swift in Sources */,
+				5144EA382279FC6200D19003 /* AccountsAddLocalWindowController.swift in Sources */,
+				84AD1EAA2031617300BC20B7 /* PasteboardFolder.swift in Sources */,
+				5144EA51227B8E4500D19003 /* AccountsFeedbinWindowController.swift in Sources */,
+				84AD1EBC2032AF5C00BC20B7 /* SidebarOutlineDataSource.swift in Sources */,
+				845A29241FC9255E007B49E3 /* SidebarCellAppearance.swift in Sources */,
+				845EE7B11FC2366500854A1F /* StarredFeedDelegate.swift in Sources */,
+				848F6AE51FC29CFB002D422E /* FaviconDownloader.swift in Sources */,
+				84C9FC7722629E1200D921D6 /* AdvancedPreferencesViewController.swift in Sources */,
+				849EE72120391F560082A1EA /* SharingServicePickerDelegate.swift in Sources */,
+				849A97981ED9EFAA007D329B /* Node-Extensions.swift in Sources */,
+				849EE70F203919360082A1EA /* AppAssets.swift in Sources */,
+				849A97531ED9EAC0007D329B /* AddFeedController.swift in Sources */,
+				5183CCE8226F68D90010922C /* AccountRefreshTimer.swift in Sources */,
+				849A97831ED9EC63007D329B /* SidebarStatusBarView.swift in Sources */,
+				51938DF2231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift in Sources */,
+				84F2D5381FC22FCC00998D64 /* TodayFeedDelegate.swift in Sources */,
+				841ABA5E20145E9200980E11 /* FolderInspectorViewController.swift in Sources */,
+				84DEE56522C32CA4005FC42C /* SmartFeedDelegate.swift in Sources */,
+				845213231FCA5B11003B6E93 /* ImageDownloader.swift in Sources */,
+				51FA73B72332D5F70090D516 /* ArticleExtractorButton.swift in Sources */,
+				51EF0F922279CA620050506E /* AccountsAddTableCellView.swift in Sources */,
+				849A97431ED9EAA9007D329B /* AddFolderWindowController.swift in Sources */,
+				8405DDA522168C62008CE1BF /* TimelineContainerViewController.swift in Sources */,
+				844B5B671FEA18E300C7C76A /* MainWIndowKeyboardHandler.swift in Sources */,
+				848D578E21543519005FFAD5 /* PasteboardFeed.swift in Sources */,
+				5144EA2F2279FAB600D19003 /* AccountsDetailViewController.swift in Sources */,
+				849A97801ED9EC42007D329B /* DetailViewController.swift in Sources */,
+				84C9FC6722629B9000D921D6 /* AppDelegate.swift in Sources */,
+				84C9FC7A22629E1200D921D6 /* AccountsTableViewBackgroundView.swift in Sources */,
+				84CAFCAF22BC8C35007694F0 /* FetchRequestOperation.swift in Sources */,
+				8426119E1FCB6ED40086A189 /* HTMLMetadataDownloader.swift in Sources */,
+				849A976E1ED9EBC8007D329B /* TimelineViewController.swift in Sources */,
+				5154368B229404D1005E1CDF /* FaviconGenerator.swift in Sources */,
+				5183CCE6226F4E110010922C /* RefreshInterval.swift in Sources */,
+				849A97771ED9EC04007D329B /* TimelineCellData.swift in Sources */,
+				841ABA6020145EC100980E11 /* BuiltinSmartFeedInspectorViewController.swift in Sources */,
+				D5E4CC54202C1361009B4FFC /* AppDelegate+Scriptability.swift in Sources */,
+				518651B223555EB20078E021 /* NNW3Document.swift in Sources */,
+				D5F4EDB5200744A700B9E363 /* ScriptingObject.swift in Sources */,
+				D5F4EDB920074D7C00B9E363 /* Folder+Scriptability.swift in Sources */,
+				849A97781ED9EC04007D329B /* TimelineCellLayout.swift in Sources */,
+				84E8E0EB202F693600562D8F /* DetailWebView.swift in Sources */,
+				849A976C1ED9EBC8007D329B /* TimelineTableRowView.swift in Sources */,
+				849A977B1ED9EC04007D329B /* UnreadIndicatorView.swift in Sources */,
+				51FA73A72332BE880090D516 /* ExtractedArticle.swift in Sources */,
+				84B99C9D1FAE83C600ECDEDB /* DeleteCommand.swift in Sources */,
+				849A97541ED9EAC0007D329B /* AddFeedWindowController.swift in Sources */,
+				5144EA40227A37EC00D19003 /* ImportOPMLWindowController.swift in Sources */,
+				849A976D1ED9EBC8007D329B /* TimelineTableView.swift in Sources */,
+				84D52E951FE588BB00D14F5B /* DetailStatusBarView.swift in Sources */,
+				D5E4CC64202C1AC1009B4FFC /* MainWindowController+Scriptability.swift in Sources */,
+				84C9FC7922629E1200D921D6 /* PreferencesWindowController.swift in Sources */,
+				84411E711FE5FBFA004B527F /* SmallIconProvider.swift in Sources */,
+				51FA73A42332BE110090D516 /* ArticleExtractor.swift in Sources */,
+				84CAFCA422BC8C08007694F0 /* FetchRequestQueue.swift in Sources */,
+				844B5B591FE9FE4F00C7C76A /* SidebarKeyboardDelegate.swift in Sources */,
+				84C9FC7C22629E1200D921D6 /* AccountsPreferencesViewController.swift in Sources */,
+				51EC114C2149FE3300B296E3 /* FolderTreeMenu.swift in Sources */,
+				849ADEE42359817E000E1B81 /* NNW3ImportController.swift in Sources */,
+				849A97A31ED9F180007D329B /* FolderTreeControllerDelegate.swift in Sources */,
+				51126DA4225FDE2F00722696 /* RSImage-Extensions.swift in Sources */,
+				845A29091FC74B8E007B49E3 /* SingleFaviconDownloader.swift in Sources */,
+				D5F4EDB720074D6500B9E363 /* Feed+Scriptability.swift in Sources */,
+				84E850861FCB60CE0072EA88 /* AuthorAvatarDownloader.swift in Sources */,
+				84E185B3203B74E500F69BFA /* SingleLineTextFieldSizer.swift in Sources */,
+				849A977A1ED9EC04007D329B /* TimelineTableCellView.swift in Sources */,
+				849A97761ED9EC04007D329B /* TimelineCellAppearance.swift in Sources */,
+				849A977F1ED9EC42007D329B /* ArticleRenderer.swift in Sources */,
+				84C9FC7822629E1200D921D6 /* GeneralPrefencesViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		849C646D1ED37A5D003D8FC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51CE1C712367721A005548FC /* testURLsOfCurrentArticle.applescript in Sources */,
+				FF3ABF13232599810074C542 /* ArticleSorterTests.swift in Sources */,
+				DD82AB0A231003F6002269DF /* SharingTests.swift in Sources */,
+				84F9EAEB213660A100CF2DE4 /* testIterativeCreateAndDeleteFeed.applescript in Sources */,
+				84F9EAF4213660A100CF2DE4 /* testGenericScript.applescript in Sources */,
+				84F9EAE6213660A100CF2DE4 /* ScriptingTests.swift in Sources */,
+				847E64A02262783000E00365 /* NSAppleEventDescriptor+UserRecordFields.swift in Sources */,
+				84F9EAED213660A100CF2DE4 /* uiScriptingTestSetup.applescript in Sources */,
+				84F9EAE8213660A100CF2DE4 /* testGetURL.applescript in Sources */,
+				84F9EAEA213660A100CF2DE4 /* testFeedExists.applescript in Sources */,
+				84F9EAF1213660A100CF2DE4 /* selectAnArticle.applescript in Sources */,
+				84F9EAE9213660A100CF2DE4 /* testNameAndUrlOfEveryFeed.applescript in Sources */,
+				84F9EAF3213660A100CF2DE4 /* testCurrentArticleIsNil.applescript in Sources */,
+				84F9EAE7213660A100CF2DE4 /* testNameOfAuthors.applescript in Sources */,
+				84F9EAEF213660A100CF2DE4 /* testNameOfEveryFolder.applescript in Sources */,
+				84F9EAF5213660A100CF2DE4 /* establishMainWindowStartingState.applescript in Sources */,
+				84F9EAF0213660A100CF2DE4 /* testFeedOPML.applescript in Sources */,
+				84F9EAF2213660A100CF2DE4 /* testTitleOfArticlesWhose.applescript in Sources */,
+				84F9EAE5213660A100CF2DE4 /* AppleScriptXCTestCase.swift in Sources */,
+				84F9EAEC213660A100CF2DE4 /* selectAFeed.applescript in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5131463D235A7BBE00387FDC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 51314636235A7BBE00387FDC /* NetNewsWire iOS Intents Extension */;
+			targetProxy = 5131463C235A7BBE00387FDC /* PBXContainerItemProxy */;
+		};
+		51554C27228B71910055115A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SyncDatabase;
+			targetProxy = 51554C26228B71910055115A /* PBXContainerItemProxy */;
+		};
+		518B2ED82351B3DD00400001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 840D617B2029031C009BC708 /* NetNewsWire-iOS */;
+			targetProxy = 518B2ED72351B3DD00400001 /* PBXContainerItemProxy */;
+		};
+		51C451AC226377C300C03939 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ArticlesDatabase;
+			targetProxy = 51C451AB226377C300C03939 /* PBXContainerItemProxy */;
+		};
+		51C451BC226377C900C03939 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Articles;
+			targetProxy = 51C451BB226377C900C03939 /* PBXContainerItemProxy */;
+		};
+		51C451C0226377D000C03939 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Account;
+			targetProxy = 51C451BF226377D000C03939 /* PBXContainerItemProxy */;
+		};
+		65ED3FA3235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSCore;
+			targetProxy = 65ED3FA4235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FA5235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSWeb;
+			targetProxy = 65ED3FA6235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FA7235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSTree;
+			targetProxy = 65ED3FA8235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FA9235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSParser;
+			targetProxy = 65ED3FAA235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FAB235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSDatabase;
+			targetProxy = 65ED3FAC235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FAD235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ArticlesDatabase;
+			targetProxy = 65ED3FAE235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FAF235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Articles;
+			targetProxy = 65ED3FB0235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FB1235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Account;
+			targetProxy = 65ED3FB2235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED3FB3235DEF6C0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SyncDatabase;
+			targetProxy = 65ED3FB4235DEF6C0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED41C5235E61550081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6581C73220CED60000F4AD34 /* Subscribe to Feed */;
+			targetProxy = 65ED41C4235E61550081F399 /* PBXContainerItemProxy */;
+		};
+		65ED41C7235E615E0081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65ED4090235DEF770081F399 /* Subscribe to Feed MAS */;
+			targetProxy = 65ED41C6235E615E0081F399 /* PBXContainerItemProxy */;
+		};
+		65ED42D0235E71F60081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Sparkle;
+			targetProxy = 65ED42CF235E71F60081F399 /* PBXContainerItemProxy */;
+		};
+		65ED42D2235E72000081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SparkleDownloader;
+			targetProxy = 65ED42D1235E72000081F399 /* PBXContainerItemProxy */;
+		};
+		65ED42D4235E72000081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SparkleInstallerConnection;
+			targetProxy = 65ED42D3235E72000081F399 /* PBXContainerItemProxy */;
+		};
+		65ED42D6235E72000081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SparkleInstallerLauncher;
+			targetProxy = 65ED42D5235E72000081F399 /* PBXContainerItemProxy */;
+		};
+		65ED42D8235E72000081F399 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SparkleInstallerStatus;
+			targetProxy = 65ED42D7235E72000081F399 /* PBXContainerItemProxy */;
+		};
+		849C64731ED37A5D003D8FC0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 849C645F1ED37A5D003D8FC0 /* NetNewsWire */;
+			targetProxy = 849C64721ED37A5D003D8FC0 /* PBXContainerItemProxy */;
+		};
+		84C37FA820DD8D8400CA8CF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSCore;
+			targetProxy = 84C37FA720DD8D8400CA8CF5 /* PBXContainerItemProxy */;
+		};
+		84C37FAC20DD8D9000CA8CF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSWeb;
+			targetProxy = 84C37FAB20DD8D9000CA8CF5 /* PBXContainerItemProxy */;
+		};
+		84C37FB020DD8D9900CA8CF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSTree;
+			targetProxy = 84C37FAF20DD8D9900CA8CF5 /* PBXContainerItemProxy */;
+		};
+		84C37FB820DD8DBB00CA8CF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSParser;
+			targetProxy = 84C37FB720DD8DBB00CA8CF5 /* PBXContainerItemProxy */;
+		};
+		84C37FC820DD8E1D00CA8CF5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RSDatabase;
+			targetProxy = 84C37FC720DD8E1D00CA8CF5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		511D43ED231FBDE800FB1562 /* LaunchScreenPad.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				511D43EE231FBDE800FB1562 /* Base */,
+			);
+			name = LaunchScreenPad.storyboard;
+			sourceTree = "<group>";
+		};
+		51314707235C41FC00387FDC /* Intents.intentdefinition */ = {
+			isa = PBXVariantGroup;
+			children = (
+				51314706235C41FC00387FDC /* Base */,
+				51314714235C420900387FDC /* en */,
+			);
+			name = Intents.intentdefinition;
+			sourceTree = "<group>";
+		};
+		513C5CEA232571C2003D4054 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				513C5CEB232571C2003D4054 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+		6581C73B20CED60100F4AD34 /* SafariExtensionViewController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6581C73C20CED60100F4AD34 /* Base */,
+			);
+			name = SafariExtensionViewController.xib;
+			sourceTree = "<group>";
+		};
+		848363002262A3BC00DA1D35 /* AddFeedSheet.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				848363012262A3BC00DA1D35 /* Base */,
+			);
+			name = AddFeedSheet.xib;
+			sourceTree = "<group>";
+		};
+		848363032262A3CC00DA1D35 /* AddFolderSheet.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				848363042262A3CC00DA1D35 /* Base */,
+			);
+			name = AddFolderSheet.xib;
+			sourceTree = "<group>";
+		};
+		848363062262A3DD00DA1D35 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				848363072262A3DD00DA1D35 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		848363092262A3F000DA1D35 /* RenameSheet.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8483630A2262A3F000DA1D35 /* Base */,
+			);
+			name = RenameSheet.xib;
+			sourceTree = "<group>";
+		};
+		8483630C2262A3FE00DA1D35 /* MainWindow.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8483630D2262A3FE00DA1D35 /* Base */,
+			);
+			name = MainWindow.storyboard;
+			sourceTree = "<group>";
+		};
+		84C9FC8022629E4800D921D6 /* Preferences.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				84C9FC8122629E4800D921D6 /* Base */,
+			);
+			name = Preferences.storyboard;
+			sourceTree = "<group>";
+		};
+		84C9FC9F2262A1B300D921D6 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				84C9FCA02262A1B300D921D6 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		84C9FCA22262A1B800D921D6 /* LaunchScreenPhone.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				84C9FCA32262A1B800D921D6 /* Base */,
+			);
+			name = LaunchScreenPhone.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		51314640235A7BBE00387FDC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51314617235A797400387FDC /* NetNewsWire_iOSintentextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		51314641235A7BBE00387FDC /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51314617235A797400387FDC /* NetNewsWire_iOSintentextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51314642235A7BBE00387FDC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51314617235A797400387FDC /* NetNewsWire_iOSintentextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		513C5CF2232571C2003D4054 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 515D4FCE2325B3D000EE1167 /* NetNewsWire_iOSshareextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		513C5CF3232571C2003D4054 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 515D4FCE2325B3D000EE1167 /* NetNewsWire_iOSshareextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		518B2ED92351B3DD00400001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 518B2EE92351B4C200400001 /* NetNewsWire_iOSTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		518B2EDA2351B3DD00400001 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 518B2EE92351B4C200400001 /* NetNewsWire_iOSTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		518B2EDB2351B3DD00400001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 518B2EE92351B4C200400001 /* NetNewsWire_iOSTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		51EC892A23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51EC892923511D3B0061B6F6 /* NetNewsWire_project_test.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51EC892B23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51EC892C23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CDF2002F0F9005947E5 /* NetNewsWireTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51EC892D23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51EC892E23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		51EC892F23511DA80061B6F6 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 515D4FCE2325B3D000EE1167 /* NetNewsWire_iOSshareextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Test;
+		};
+		6581C74720CED60100F4AD34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		6581C74820CED60100F4AD34 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		65ED4080235DEF6C0081F399 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED40F2235DF5E00081F399 /* NetNewsWire_macapp_target_macappstore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				PRODUCT_NAME = NetNewsWire;
+			};
+			name = Debug;
+		};
+		65ED4081235DEF6C0081F399 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED40F2235DF5E00081F399 /* NetNewsWire_macapp_target_macappstore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				PRODUCT_NAME = NetNewsWire;
+			};
+			name = Test;
+		};
+		65ED4082235DEF6C0081F399 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED40F2235DF5E00081F399 /* NetNewsWire_macapp_target_macappstore.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				PRODUCT_NAME = NetNewsWire;
+			};
+			name = Release;
+		};
+		65ED409A235DEF770081F399 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED4186235E045B0081F399 /* NetNewsWire_safariextension_target_macappstore.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "Subscribe to Feed";
+			};
+			name = Debug;
+		};
+		65ED409B235DEF770081F399 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED4186235E045B0081F399 /* NetNewsWire_safariextension_target_macappstore.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "Subscribe to Feed";
+			};
+			name = Test;
+		};
+		65ED409C235DEF770081F399 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65ED4186235E045B0081F399 /* NetNewsWire_safariextension_target_macappstore.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "Subscribe to Feed";
+			};
+			name = Release;
+		};
+		840D61A42029031E009BC708 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		840D61A52029031E009BC708 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51121AA12265430A00BC0EC1 /* NetNewsWire_iOSapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		849C64781ED37A5D003D8FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CDD2002F0BE005947E5 /* NetNewsWire_project_debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		849C64791ED37A5D003D8FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CDC2002F0BE005947E5 /* NetNewsWire_project_release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		849C647B1ED37A5D003D8FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		849C647C1ED37A5D003D8FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CE02002F0FA005947E5 /* NetNewsWire_macapp_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		849C647E1ED37A5D003D8FC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CDF2002F0F9005947E5 /* NetNewsWireTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		849C647F1ED37A5D003D8FC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D5907CDF2002F0F9005947E5 /* NetNewsWireTests_target.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5131463F235A7BBE00387FDC /* Build configuration list for PBXNativeTarget "NetNewsWire iOS Intents Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51314640235A7BBE00387FDC /* Debug */,
+				51314641235A7BBE00387FDC /* Test */,
+				51314642235A7BBE00387FDC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		513C5CFC232571C2003D4054 /* Build configuration list for PBXNativeTarget "NetNewsWire iOS Share Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				513C5CF2232571C2003D4054 /* Debug */,
+				51EC892F23511DA80061B6F6 /* Test */,
+				513C5CF3232571C2003D4054 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		518B2EE72351B3DD00400001 /* Build configuration list for PBXNativeTarget "NetNewsWire-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				518B2ED92351B3DD00400001 /* Debug */,
+				518B2EDA2351B3DD00400001 /* Test */,
+				518B2EDB2351B3DD00400001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6581C75620CED60100F4AD34 /* Build configuration list for PBXNativeTarget "Subscribe to Feed" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6581C74720CED60100F4AD34 /* Debug */,
+				51EC892E23511DA80061B6F6 /* Test */,
+				6581C74820CED60100F4AD34 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65ED407F235DEF6C0081F399 /* Build configuration list for PBXNativeTarget "NetNewsWire MAS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65ED4080235DEF6C0081F399 /* Debug */,
+				65ED4081235DEF6C0081F399 /* Test */,
+				65ED4082235DEF6C0081F399 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65ED4099235DEF770081F399 /* Build configuration list for PBXNativeTarget "Subscribe to Feed MAS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65ED409A235DEF770081F399 /* Debug */,
+				65ED409B235DEF770081F399 /* Test */,
+				65ED409C235DEF770081F399 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		840D61A32029031E009BC708 /* Build configuration list for PBXNativeTarget "NetNewsWire-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				840D61A42029031E009BC708 /* Debug */,
+				51EC892D23511DA80061B6F6 /* Test */,
+				840D61A52029031E009BC708 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		849C645B1ED37A5D003D8FC0 /* Build configuration list for PBXProject "NetNewsWire" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				849C64781ED37A5D003D8FC0 /* Debug */,
+				51EC892A23511DA80061B6F6 /* Test */,
+				849C64791ED37A5D003D8FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		849C647A1ED37A5D003D8FC0 /* Build configuration list for PBXNativeTarget "NetNewsWire" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				849C647B1ED37A5D003D8FC0 /* Debug */,
+				51EC892B23511DA80061B6F6 /* Test */,
+				849C647C1ED37A5D003D8FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		849C647D1ED37A5D003D8FC0 /* Build configuration list for PBXNativeTarget "NetNewsWireTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				849C647E1ED37A5D003D8FC0 /* Debug */,
+				51EC892C23511DA80061B6F6 /* Test */,
+				849C647F1ED37A5D003D8FC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 849C64581ED37A5D003D8FC0 /* Project object */;
+}

--- a/tests/data/xml-animals.plist
+++ b/tests/data/xml-animals.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AnimalColors</key>
+	<dict>
+		<key>lamb</key>
+		<string>black</string>
+		<key>pig</key>
+		<string>pink</string>
+		<key>worm</key>
+		<string>pink</string>
+	</dict>
+	<key>AnimalSmells</key>
+	<dict>
+		<key>lamb</key>
+		<string>lambish</string>
+		<key>pig</key>
+		<string>piggish</string>
+		<key>worm</key>
+		<string>wormy</string>
+	</dict>
+	<key>AnimalSounds</key>
+	<dict>
+		<key>Lisa</key>
+		<string>Why is the worm talking like a lamb?</string>
+		<key>lamb</key>
+		<string>baa</string>
+		<key>pig</key>
+		<string>oink</string>
+		<key>worm</key>
+		<string>baa</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This continues from #44

Some comments brought over from there:
1. ~The serde tests highlighted that documents that don't begin with exactly `<?xml`, with no preceding whitespace, will be treated as ascii, which might not be desirable.~
2. ~The master branch is broken due to denying warnings and a deprecation, I switched to using `swap_remove`.~
3. I had to allow escaping `\` (`\\`) because the test that parses netnewswire.pbxproj fails without it.

The fuzzer quickly found an infinite loop in handling block comments. I let it run for another 10 hours, it tried 510 million inputs without finding anything else.

The related issue (#42) contains a suggestion that it should be renamed to `OpenStepReader` or similar. I don't know the full history of the format (wikipedia discusses it [here](https://en.wikipedia.org/wiki/Property_list)). If I'm understanding it correctly then NextStep read integers as strings, OpenStep supported integers and real numbers, GNUStep supported NSValue and NSDate. This is missing support for floats.