### PR TITLE
Declarative macros for creating dictionaries & arrays

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -27,6 +27,15 @@ impl Dictionary {
         }
     }
 
+    /// Create a new map with capacity for `n` key-value pairs. (Does not allocate if `n` is zero.)
+    ///
+    /// Computes in **O(n)** time.
+    pub fn with_capacity(n: usize) -> Self {
+        Dictionary {
+            map: IndexMap::with_capacity(n),
+        }
+    }
+
     /// Clears the dictionary, removing all values.
     #[inline]
     pub fn clear(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod data;
 mod date;
 mod error;
 mod integer;
+mod macros;
 mod uid;
 mod value;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,55 @@
+/// Create a [`Dictionary`](crate::Dictionary) from a list of key-value pairs
+///
+/// ## Example
+///
+/// ```
+/// # use plist::{plist_dict, Value};
+/// let map = plist_dict! {
+///     "a" => 1,
+///     "b" => 2,
+/// };
+/// assert_eq!(map["a"], Value::from(1));
+/// assert_eq!(map["b"], Value::from(2));
+/// assert_eq!(map.get("c"), None);
+/// ```
+#[macro_export]
+macro_rules! plist_dict {
+    (@single $($x:tt)*) => (());
+    (@count $($rest:expr),*) => (<[()]>::len(&[$($crate::plist_dict!(@single $rest)),*]));
+
+    ($($key:expr => $value:expr,)+) => { $crate::plist_dict!($($key => $value),+) };
+    ($($key:expr => $value:expr),*) => {
+        {
+            let item_count = $crate::plist_dict!(@count $($key),*);
+            let mut _dict = $crate::Dictionary::with_capacity(item_count);
+            $(
+                let _ = _dict.insert(::std::string::String::from($key), $crate::Value::from($value));
+            )*
+            _dict
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_plist_dict() {
+        let digits = plist_dict! {
+            "one" => 1,
+            "two" => 2,
+        };
+        assert_eq!(digits.len(), 2);
+        assert_eq!(digits["one"], 1.into());
+        assert_eq!(digits["two"], 2.into());
+
+        let empty = plist_dict! {};
+        assert!(empty.is_empty());
+
+        let _nested_compiles = plist_dict! {
+            "inner" => plist_dict! {
+                "one" => 1,
+                "two" => 2,
+            },
+        };
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,6 +55,8 @@ macro_rules! plist_array {
             $crate::Value::Array(_array)
         }
     };
+
+    ($value:expr; $n:expr) => ($crate::Value::Array(::std::vec![$crate::Value::from($value); $n]));
 }
 
 #[cfg(test)]
@@ -92,6 +94,12 @@ mod tests {
             digits,
             &vec![Value::from(1), Value::from(2), Value::from(3)],
         );
+
+        let repeated = plist_array![1; 5];
+        let Value::Array(repeated) = &repeated else {
+            panic!("wrong plist::Value variant, expected Value::Array, got {repeated:?}");
+        };
+        assert_eq!(repeated, &vec![Value::from(1); 5]);
 
         let empty = plist_array![];
         let Value::Array(empty) = &empty else {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,8 +36,11 @@ macro_rules! plist_dict {
 ///
 /// ```
 /// # use plist::{plist_array, Value};
-/// let array = plist_array! [1, 2, 3];
-/// assert_eq!(array, Value::Array(vec![Value::from(1), Value::from(2), Value::from(3)]));
+/// let array = plist_array![1, 2];
+/// assert_eq!(array, Value::Array(vec![Value::from(1), Value::from(2)]));
+///
+/// let other_array = plist_array!["hi"; 2];
+/// assert_eq!(other_array, Value::Array(vec![Value::from("hi"), Value::from("hi")]));
 /// ```
 #[macro_export]
 macro_rules! plist_array {


### PR DESCRIPTION
These two types in particular can be a bit finnicky to build by hand, so I've made some declarative macros for the job based on the popular crate [maplit](https://github.com/bluss/maplit)

They pre-allocate the correct capacity ahead of time thanks to macro counting magics 🧙🏼‍♂️ (For this, I added `Dictionary::with_capacity`, copying the documentation from the internal `IndexMap`)

I could always make a separate crate for these if you didn't want them in the main repo, but I figured they're a useful addition. Happy to bikeshed the macro names, I just picked _something_ so I could make the code work and debate later :)

As an aside, please consider adjusting workflow permissions for a better contributor experience: https://matklad.github.io/2022/10/24/actions-permissions.html