### PR TITLE
Fix clippy lints in tests

### DIFF
--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -84,9 +84,7 @@ fn new_serializer() -> Serializer<VecWriter> {
     Serializer::new(VecWriter::new())
 }
 
-fn new_deserializer<'event>(
-    events: Vec<Event<'event>>,
-) -> Deserializer<'event, Vec<Result<Event<'event>, Error>>> {
+fn new_deserializer(events: Vec<Event>) -> Deserializer<Vec<Result<Event, Error>>> {
     let result_events = events.into_iter().map(Ok).collect();
     Deserializer::new(result_events)
 }
@@ -105,7 +103,7 @@ where
         Value::Boolean(false)
     };
 
-    assert_eq!(&events[..], &expected_events[..]);
+    assert_eq!(&events[..], expected_events);
 
     if roundtrip_value {
         let expected_value = Value::from_events(expected_events.iter().cloned().map(Ok))

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -715,7 +715,7 @@ mod tests {
         let streaming_parser = BinaryReader::new(Cursor::new(buf_inner));
 
         let events: Vec<Result<_, _>> = streaming_parser.collect();
-        let value_decoded_from_encode = Value::from_events(events.into_iter()).unwrap();
+        let value_decoded_from_encode = Value::from_events(events).unwrap();
 
         assert_eq!(value_to_encode, value_decoded_from_encode);
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -802,7 +802,7 @@ mod tests {
         );
 
         let date: Date = SystemTime::now().into();
-        assert_eq!(Value::Date(date.clone()).as_date(), Some(date));
+        assert_eq!(Value::Date(date).as_date(), Some(date));
 
         assert_eq!(Value::Real(0.0).as_real(), Some(0.0));
         assert_eq!(Value::Integer(1.into()).as_signed_integer(), Some(1));
@@ -838,7 +838,7 @@ mod tests {
             EndCollection,
         ];
 
-        let value = Builder::build(events.into_iter().map(|e| Ok(e)));
+        let value = Builder::build(events.into_iter().map(Ok));
 
         // Expected output
         let lines = vec![


### PR DESCRIPTION
Something I noticed while working on #140 when I wanted to make sure the macro invocations weren't producing lints. For the unaware, clippy doesn't check code in `#[cfg(test)]` by default unless you pass the `--tests` flag, at which point I noticed several errors in existing code

I also noticed that clippy isn't being run as part of the GitHub workflow, which I could add as part of the lint job if you'd like :)