### PR TITLE
add a plist macro - copied from serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ serde = { version = "1.0.2", optional = true }
 [dev-dependencies]
 serde_derive = { version = "1.0.2" }
 serde_yaml = "0.8.21"
+trybuild = { version = "1.0.81", features = ["diff"] }
+macrotest = "1.0.12"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,6 @@ mod error;
 mod integer;
 mod uid;
 mod value;
-#[macro_use]
-#[cfg(feature = "serde")]
 mod macros;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ mod error;
 mod integer;
 mod uid;
 mod value;
+#[macro_use]
+#[cfg(feature = "serde")]
 mod macros;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ mod error;
 mod integer;
 mod uid;
 mod value;
+mod macros;
 
 #[cfg(feature = "serde")]
 pub use data::Data;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,303 @@
+/// Construct a `plist::Value` from a JSON literal.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let value = plist!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///         "features": [
+///             "serde",
+///         ],
+///         "homepage": null
+///     }
+/// });
+/// ```
+///
+/// Variables or expressions can be interpolated into the PList literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into a object key must
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `plist!` macro will panic.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let code = 200;
+/// let features = vec!["serde", "plist"];
+///
+/// let value = plist!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         features[0]: features[1]
+///     }
+/// });
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let value = plist!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! plist {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($plist:tt)+) => {
+        plist_internal!($($plist)+)
+    };
+}
+
+// Rocket relies on this because they export their own `plist!` with a different
+// doc comment than ours, and various Rust bugs prevent them from calling our
+// `plist!` from their `plist!` so they call `plist_internal!` directly. Check with
+// @SergioBenitez before making breaking changes to this macro.
+//
+// Changes are fine as long as `plist_internal!` does not call any new helper
+// macros and can still be invoked as `plist_internal!($($plist)+)`.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! plist_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: plist_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        plist_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        plist_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        plist_internal!(@array [$($elems,)* plist_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        plist_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: plist_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        plist_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        plist_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        plist_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        plist_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        plist_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        plist_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        plist_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: plist_internal!($($plist)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::Value::Null
+    };
+
+    (true) => {
+        $crate::Value::Bool(true)
+    };
+
+    (false) => {
+        $crate::Value::Bool(false)
+    };
+
+    ([]) => {
+        $crate::Value::Array(plist_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::Array(plist_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Value::Dictionary($crate::Dictionary::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::Dictionary({
+            let mut object = $crate::Dictionary::new();
+            plist_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::to_value(&$other).unwrap()
+    };
+}
+
+// The plist_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to plist::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,8 +9,7 @@
 ///     "payload": {
 ///         "features": [
 ///             "serde",
-///         ],
-///         "homepage": null
+///         ]
 ///     }
 /// });
 /// ```
@@ -84,11 +83,6 @@ macro_rules! plist_internal {
         plist_internal_vec![$($elems),*]
     };
 
-    // Next element is `null`.
-    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
-        plist_internal!(@array [$($elems,)* plist_internal!(null)] $($rest)*)
-    };
-
     // Next element is `true`.
     (@array [$($elems:expr,)*] true $($rest:tt)*) => {
         plist_internal!(@array [$($elems,)* plist_internal!(true)] $($rest)*)
@@ -156,11 +150,6 @@ macro_rules! plist_internal {
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
         let _ = $object.insert(($($key)+).into(), $value);
-    };
-
-    // Next value is `null`.
-    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
-        plist_internal!(@object $object [$($key)+] (plist_internal!(null)) $($rest)*);
     };
 
     // Next value is `true`.
@@ -240,16 +229,12 @@ macro_rules! plist_internal {
     // Must be invoked as: plist_internal!($($plist)+)
     //////////////////////////////////////////////////////////////////////////
 
-    (null) => {
-        $crate::Value::Null
-    };
-
     (true) => {
-        $crate::Value::Bool(true)
+        $crate::Value::Boolean(true)
     };
 
     (false) => {
-        $crate::Value::Bool(false)
+        $crate::Value::Boolean(false)
     };
 
     ([]) => {

--- a/tests/expand/dict.expanded.rs
+++ b/tests/expand/dict.expanded.rs
@@ -1,0 +1,35 @@
+use plist::plist;
+fn dict() {
+    ::plist::Value::Dictionary({
+        let mut object = ::plist::Dictionary::new();
+        let _ = object.insert(("a").into(), ::plist::Value::Boolean(true));
+        let _ = object.insert(("b").into(), ::plist::to_value(&"astring").unwrap());
+        let _ = object.insert(("c").into(), ::plist::to_value(&1).unwrap());
+        let _ = object.insert(("d").into(), ::plist::to_value(&1.0).unwrap());
+        let _ = object
+            .insert(
+                ("e").into(),
+                ::plist::Value::Array(
+                    <[_]>::into_vec(
+                        #[rustc_box]
+                        ::alloc::boxed::Box::new([
+                            ::plist::to_value(&1).unwrap(),
+                            ::plist::to_value(&2).unwrap(),
+                            ::plist::to_value(&3).unwrap(),
+                        ]),
+                    ),
+                ),
+            );
+        let _ = object
+            .insert(
+                ("f").into(),
+                ::plist::Value::Dictionary({
+                    let mut object = ::plist::Dictionary::new();
+                    let _ = object.insert(("a").into(), ::plist::to_value(&1).unwrap());
+                    let _ = object.insert(("b").into(), ::plist::to_value(&2).unwrap());
+                    object
+                }),
+            );
+        object
+    });
+}

--- a/tests/expand/dict.rs
+++ b/tests/expand/dict.rs
@@ -1,0 +1,12 @@
+use plist::plist;
+
+fn dict() {
+    plist!({
+        "a" : true,
+        "b" : "astring",
+        "c" : 1,
+        "d" : 1.0,
+        "e" : [1, 2, 3],
+        "f" : { "a" : 1, "b" : 2 },
+    });
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,11 @@
+#[cfg_attr(miri, ignore = "incompatible with miri")]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}
+
+#[test]
+pub fn pass() {
+    macrotest::expand("tests/expand/*.rs");
+}

--- a/tests/ui/missing_colon.rs
+++ b/tests/ui/missing_colon.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" });
+}

--- a/tests/ui/missing_colon.stderr
+++ b/tests/ui/missing_colon.stderr
@@ -1,0 +1,12 @@
+error: unexpected end of macro invocation
+ --> tests/ui/missing_colon.rs:4:5
+  |
+4 |     plist!({ "a" });
+  |     ^^^^^^^^^^^^^^^ missing tokens in macro arguments
+  |
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `plist_internal` which comes from the expansion of the macro `plist` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_comma.rs
+++ b/tests/ui/missing_comma.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "1": "" "2": "" });
+}

--- a/tests/ui/missing_comma.stderr
+++ b/tests/ui/missing_comma.stderr
@@ -1,0 +1,13 @@
+error: no rules expected the token `"2"`
+ --> tests/ui/missing_comma.rs:4:22
+  |
+4 |     plist!({ "1": "" "2": "" });
+  |                     -^^^ no rules expected this token in macro call
+  |                     |
+  |                     help: missing comma here
+  |
+note: while trying to match `,`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |              ^

--- a/tests/ui/missing_value.rs
+++ b/tests/ui/missing_value.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : });
+}

--- a/tests/ui/missing_value.stderr
+++ b/tests/ui/missing_value.stderr
@@ -1,0 +1,12 @@
+error: unexpected end of macro invocation
+ --> tests/ui/missing_value.rs:4:5
+  |
+4 |     plist!({ "a" : });
+  |     ^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+  |
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `plist_internal` which comes from the expansion of the macro `plist` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/not_found.rs
+++ b/tests/ui/not_found.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : x });
+}

--- a/tests/ui/not_found.stderr
+++ b/tests/ui/not_found.stderr
@@ -1,0 +1,5 @@
+error[E0425]: cannot find value `x` in this scope
+ --> tests/ui/not_found.rs:4:20
+  |
+4 |     plist!({ "a" : x });
+  |                    ^ not found in this scope

--- a/tests/ui/parse_expr.rs
+++ b/tests/ui/parse_expr.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : ~ });
+}

--- a/tests/ui/parse_expr.stderr
+++ b/tests/ui/parse_expr.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `~`
+ --> tests/ui/parse_expr.rs:4:20
+  |
+4 |     plist!({ "a" : ~ });
+  |                    ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$e:expr`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |      ^^^^^^^

--- a/tests/ui/parse_key.rs
+++ b/tests/ui/parse_key.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "".s : true });
+}

--- a/tests/ui/parse_key.stderr
+++ b/tests/ui/parse_key.stderr
@@ -1,0 +1,5 @@
+error[E0609]: no field `s` on type `&'static str`
+ --> tests/ui/parse_key.rs:4:17
+  |
+4 |     plist!({ "".s : true });
+  |                 ^ unknown field

--- a/tests/ui/unexpected_after_array_element.rs
+++ b/tests/ui/unexpected_after_array_element.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!([ true => ]);
+}

--- a/tests/ui/unexpected_after_array_element.stderr
+++ b/tests/ui/unexpected_after_array_element.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `=>`
+ --> tests/ui/unexpected_after_array_element.rs:4:19
+  |
+4 |     plist!([ true => ]);
+  |                   ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_after_map_entry.rs
+++ b/tests/ui/unexpected_after_map_entry.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "k": true => });
+}

--- a/tests/ui/unexpected_after_map_entry.stderr
+++ b/tests/ui/unexpected_after_map_entry.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `=>`
+ --> tests/ui/unexpected_after_map_entry.rs:4:24
+  |
+4 |     plist!({ "k": true => });
+  |                        ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_colon.rs
+++ b/tests/ui/unexpected_colon.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ : true });
+}

--- a/tests/ui/unexpected_colon.stderr
+++ b/tests/ui/unexpected_colon.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `:`
+ --> tests/ui/unexpected_colon.rs:4:14
+  |
+4 |     plist!({ : true });
+  |              ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_comma.rs
+++ b/tests/ui/unexpected_comma.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" , "b": true });
+}

--- a/tests/ui/unexpected_comma.stderr
+++ b/tests/ui/unexpected_comma.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `,`
+ --> tests/ui/unexpected_comma.rs:4:18
+  |
+4 |     plist!({ "a" , "b": true });
+  |                  ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro


### PR DESCRIPTION
i copied the json macro from serde and modified it i create plist::Value from json annotation. This is super handy when working with lockdown and usbmuxd messages.

I am relatively new to rust, thus i would appreciate any feedback.

The original macro was copied from here:
https://github.com/serde-rs/json/blob/c4f24f3be29a3d096d3ac7b1d5594777a613ec0d/src/macros.rs