### PR TITLE
Add clippy to CI & fix lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cargo clippy
+        run: cargo clippy --tests
+
       - name: Check for broken intra-doc links
         run: cargo doc --all-features --document-private-items --no-deps
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -117,7 +117,7 @@ pub mod serde_impls {
 
     struct DataVisitor;
 
-    impl<'de> de::Visitor<'de> for DataVisitor {
+    impl de::Visitor<'_> for DataVisitor {
         type Value = Data;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/date.rs
+++ b/src/date.rs
@@ -157,7 +157,7 @@ pub mod serde_impls {
 
     struct DateStrVisitor;
 
-    impl<'de> Visitor<'de> for DateStrVisitor {
+    impl Visitor<'_> for DateStrVisitor {
         type Value = Date;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/de.rs
+++ b/src/de.rs
@@ -103,7 +103,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::Deserializer<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::Deserializer<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {
@@ -268,7 +268,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::EnumAccess<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::EnumAccess<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {
@@ -283,7 +283,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::VariantAccess<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::VariantAccess<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -175,7 +175,7 @@ impl Dictionary {
 /// }
 /// # ;
 /// ```
-impl<'a> ops::Index<&'a str> for Dictionary {
+impl ops::Index<&str> for Dictionary {
     type Output = Value;
 
     fn index(&self, index: &str) -> &Value {
@@ -192,7 +192,7 @@ impl<'a> ops::Index<&'a str> for Dictionary {
 /// #
 /// dict["key"] = "value".into();
 /// ```
-impl<'a> ops::IndexMut<&'a str> for Dictionary {
+impl ops::IndexMut<&str> for Dictionary {
     fn index_mut(&mut self, index: &str) -> &mut Value {
         self.map.get_mut(index).expect("no entry found for key")
     }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -9,8 +9,7 @@ pub struct Integer {
 impl Integer {
     /// Returns the value as an `i64` if it can be represented by that type.
     pub fn as_signed(self) -> Option<i64> {
-        if self.value >= i128::from(i64::min_value()) && self.value <= i128::from(i64::max_value())
-        {
+        if self.value >= i128::from(i64::MIN) && self.value <= i128::from(i64::MAX) {
             Some(self.value as i64)
         } else {
             None
@@ -19,7 +18,7 @@ impl Integer {
 
     /// Returns the value as a `u64` if it can be represented by that type.
     pub fn as_unsigned(self) -> Option<u64> {
-        if self.value >= 0 && self.value <= i128::from(u64::max_value()) {
+        if self.value >= 0 && self.value <= i128::from(u64::MAX) {
             Some(self.value as u64)
         } else {
             None
@@ -147,7 +146,7 @@ pub mod serde_impls {
 
     struct IntegerVisitor;
 
-    impl<'de> Visitor<'de> for IntegerVisitor {
+    impl Visitor<'_> for IntegerVisitor {
         type Value = Integer;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -326,13 +326,13 @@ struct DateSerializer<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> DateSerializer<'a, W> {
+impl<W: Writer> DateSerializer<'_, W> {
     fn expecting_date_error(&self) -> Error {
         ser::Error::custom("plist date string expected")
     }
 }
 
-impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
+impl<W: Writer> ser::Serializer for DateSerializer<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -488,13 +488,13 @@ struct UidSerializer<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> UidSerializer<'a, W> {
+impl<W: Writer> UidSerializer<'_, W> {
     fn expecting_uid_error(&self) -> Error {
         ser::Error::custom("plist uid expected")
     }
 }
 
-impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
+impl<W: Writer> ser::Serializer for UidSerializer<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -650,7 +650,7 @@ pub struct Compound<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> ser::SerializeSeq for Compound<'a, W> {
+impl<W: Writer> ser::SerializeSeq for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -664,7 +664,7 @@ impl<'a, W: Writer> ser::SerializeSeq for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTuple for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTuple for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -678,7 +678,7 @@ impl<'a, W: Writer> ser::SerializeTuple for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTupleStruct for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTupleStruct for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -692,7 +692,7 @@ impl<'a, W: Writer> ser::SerializeTupleStruct for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTupleVariant for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTupleVariant for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -707,7 +707,7 @@ impl<'a, W: Writer> ser::SerializeTupleVariant for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeMap for Compound<'a, W> {
+impl<W: Writer> ser::SerializeMap for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -726,7 +726,7 @@ impl<'a, W: Writer> ser::SerializeMap for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeStruct for Compound<'a, W> {
+impl<W: Writer> ser::SerializeStruct for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -746,7 +746,7 @@ impl<'a, W: Writer> ser::SerializeStruct for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeStructVariant for Compound<'a, W> {
+impl<W: Writer> ser::SerializeStructVariant for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -360,7 +360,7 @@ fn map_next_step_to_unicode(c: char) -> char {
 
     let index = c as usize;
 
-    if index < 128 || index > 0xff {
+    if !(128..=0xff).contains(&index) {
         return c;
     }
 

--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -59,7 +59,7 @@ impl<R: Read> Read for PosReader<R> {
         let count = self.reader.read(buf)?;
         self.pos
             .checked_add(count as u64)
-            .expect("file cannot be larger than `u64::max_value()` bytes");
+            .expect("file cannot be larger than `u64::MAX` bytes");
         Ok(count)
     }
 }
@@ -249,7 +249,7 @@ impl<R: Read + Seek> BinaryReader<R> {
             (0x1, 3) => Some(Event::Integer(self.read_be_i64()?.into())),
             (0x1, 4) => {
                 let value = self.read_be_i128()?;
-                if value < 0 || value > i128::from(u64::max_value()) {
+                if value < 0 || value > i128::from(u64::MAX) {
                     return Err(self.with_pos(ErrorKind::IntegerOutOfRange));
                 }
                 Some(Event::Integer((value as u64).into()))

--- a/src/stream/binary_writer.rs
+++ b/src/stream/binary_writer.rs
@@ -470,13 +470,13 @@ impl<W: Write> BinaryWriter<W> {
             }
             Value::Integer(v) => {
                 if let Some(v) = v.as_signed() {
-                    if v >= 0 && v <= i64::from(u8::max_value()) {
+                    if v >= 0 && v <= i64::from(u8::MAX) {
                         self.writer.write_exact(&[0x10, v as u8])?;
-                    } else if v >= 0 && v <= i64::from(u16::max_value()) {
+                    } else if v >= 0 && v <= i64::from(u16::MAX) {
                         let mut buf: [_; 3] = [0x11, 0, 0];
                         buf[1..].copy_from_slice(&(v as u16).to_be_bytes());
                         self.writer.write_exact(&buf)?;
-                    } else if v >= 0 && v <= i64::from(u32::max_value()) {
+                    } else if v >= 0 && v <= i64::from(u32::MAX) {
                         let mut buf: [_; 5] = [0x12, 0, 0, 0, 0];
                         buf[1..].copy_from_slice(&(v as u32).to_be_bytes());
                         self.writer.write_exact(&buf)?;
@@ -486,7 +486,7 @@ impl<W: Write> BinaryWriter<W> {
                         self.writer.write_exact(&buf)?;
                     }
                 } else if let Some(v) = v.as_unsigned() {
-                    // `u64`s larger than `i64::max_value()` are stored as signed 128 bit
+                    // `u64`s larger than `i64::MAX` are stored as signed 128 bit
                     // integers.
                     let mut buf: [_; 17] = [0x14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
                     buf[1..].copy_from_slice(&i128::from(v).to_be_bytes());
@@ -514,13 +514,13 @@ impl<W: Write> BinaryWriter<W> {
             }
             Value::Uid(v) => {
                 let v = v.get();
-                if v <= u64::from(u8::max_value()) {
+                if v <= u64::from(u8::MAX) {
                     self.writer.write_exact(&[0x80, v as u8])?;
-                } else if v <= u64::from(u16::max_value()) {
+                } else if v <= u64::from(u16::MAX) {
                     let mut buf: [_; 3] = [0x81, 0, 0];
                     buf[1..].copy_from_slice(&(v as u16).to_be_bytes());
                     self.writer.write_exact(&buf)?;
-                } else if v <= u64::from(u32::max_value()) {
+                } else if v <= u64::from(u32::MAX) {
                     let mut buf: [_; 5] = [0x83, 0, 0, 0, 0];
                     buf[1..].copy_from_slice(&(v as u32).to_be_bytes());
                     self.writer.write_exact(&buf)?;
@@ -591,13 +591,13 @@ fn write_plist_value_ty_and_size(
 ) -> Result<(), Error> {
     if size < 0x0f {
         writer.write_exact(&[token | (size as u8)])?;
-    } else if size <= u8::max_value() as usize {
+    } else if size <= u8::MAX as usize {
         writer.write_exact(&[token | 0x0f, 0x10, size as u8])?;
-    } else if size <= u16::max_value() as usize {
+    } else if size <= u16::MAX as usize {
         let mut buf: [_; 4] = [token | 0x0f, 0x11, 0, 0];
         buf[2..].copy_from_slice(&(size as u16).to_be_bytes());
         writer.write_exact(&buf)?;
-    } else if size <= u32::max_value() as usize {
+    } else if size <= u32::MAX as usize {
         let mut buf: [_; 6] = [token | 0x0f, 0x12, 0, 0, 0, 0];
         buf[2..].copy_from_slice(&(size as u32).to_be_bytes());
         writer.write_exact(&buf)?;
@@ -645,7 +645,7 @@ impl<W: Write> Write for PosWriter<W> {
         self.pos = self
             .pos
             .checked_add(count)
-            .expect("binary plist cannot be larger than `usize::max_value()` bytes");
+            .expect("binary plist cannot be larger than `usize::MAX` bytes");
         Ok(count)
     }
 
@@ -670,7 +670,7 @@ impl ObjectRef {
     }
 }
 
-impl<'a> Value<'a> {
+impl Value<'_> {
     fn into_owned(self) -> Value<'static> {
         match self {
             Value::Boolean(v) => Value::Boolean(v),

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -115,10 +115,7 @@ impl XmlWriteOptions {
             return self.indent(0, 0);
         }
 
-        assert!(
-            indent_str.chars().all(|chr| chr.is_ascii()),
-            "indent str must be ascii"
-        );
+        assert!(indent_str.is_ascii(), "indent str must be ascii");
         let indent_str = indent_str.as_bytes();
         assert!(
             indent_str.iter().all(|chr| chr == &indent_str[0]),

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -8,21 +8,6 @@ use crate::{
     Date, Integer,
 };
 
-#[derive(Clone, PartialEq, Eq)]
-struct ElmName(Box<[u8]>);
-
-impl From<&[u8]> for ElmName {
-    fn from(bytes: &[u8]) -> Self {
-        ElmName(Box::from(bytes))
-    }
-}
-
-impl AsRef<[u8]> for ElmName {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
 pub struct XmlReader<R: BufRead> {
     buffer: Vec<u8>,
     started: bool,

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -328,7 +328,7 @@ fn write_data_base64(
     for (i, line) in data.chunks(DATA_MAX_LINE_BYTES).enumerate() {
         // Write newline
         if write_initial_newline || i > 0 {
-            writer.write_all(&[b'\n'])?;
+            writer.write_all(b"\n")?;
         }
 
         // Write indent

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -71,7 +71,7 @@ pub mod serde_impls {
 
     struct UidU64Visitor;
 
-    impl<'de> Visitor<'de> for UidU64Visitor {
+    impl Visitor<'_> for UidU64Visitor {
         type Value = Uid;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/value.rs
+++ b/src/value.rs
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(Value::Integer(1.into()).as_unsigned_integer(), Some(1));
         assert_eq!(Value::Integer((-1).into()).as_unsigned_integer(), None);
         assert_eq!(
-            Value::Integer((i64::max_value() as u64 + 1).into()).as_signed_integer(),
+            Value::Integer((i64::MAX as u64 + 1).into()).as_signed_integer(),
             None
         );
         assert_eq!(Value::String("2".to_owned()).as_string(), Some("2"));


### PR DESCRIPTION
`--tests` runs Clippy with `#[cfg(test)]`, allowing it to check tests too

Note: in its current configuration, Clippy is only checking with default features. Let me know if you'd prefer something else