### PR TITLE
Fix type inference issue in binary_reader.rs

### DIFF
--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -249,7 +249,7 @@ impl<R: Read + Seek> BinaryReader<R> {
             (0x1, 3) => Some(Event::Integer(self.read_be_i64()?.into())),
             (0x1, 4) => {
                 let value = self.read_be_i128()?;
-                if value < 0 || value > u64::max_value().into() {
+                if value < 0 || value > i128::from(u64::max_value()) {
                     return Err(self.with_pos(ErrorKind::IntegerOutOfRange));
                 }
                 Some(Event::Integer((value as u64).into()))


### PR DESCRIPTION
This issue happened after updating tauri-cli global package and tauri packages inside of the project from 2.3.1 to 2.4.0 and rust from 1.85.0 to 1.85.1 on m3 max macbook pro. I was working on a tauri project then it gave this errors and couldn't compiled it. This minor change fixed it.