### PR TITLE
Fixed a compilation error related to u64 max value

### DIFF
--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -249,7 +249,7 @@ impl<R: Read + Seek> BinaryReader<R> {
             (0x1, 3) => Some(Event::Integer(self.read_be_i64()?.into())),
             (0x1, 4) => {
                 let value = self.read_be_i128()?;
-                if value < 0 || value > u64::max_value().into() {
+                if value < 0 || value > u64::MAX as i128 {
                     return Err(self.with_pos(ErrorKind::IntegerOutOfRange));
                 }
                 Some(Event::Integer((value as u64).into()))


### PR DESCRIPTION
This pull request addresses a compilation error that occurs with the latest Rust version.

```
error[E0283]: type annotations needed
   --> src/stream/binary_reader.rs:252:58
    |
252 |                 if value < 0 || value > u64::max_value().into() {
    |                                       -                  ^^^^
    |                                       |
    |                                       type must be known at this point
    |
    = note: multiple `impl`s satisfying `i128: PartialOrd<_>` found in the following crates: `core`, `deranged`:
            - impl PartialOrd for i128;
            - impl<MIN, MAX> PartialOrd<deranged::RangedI128<MIN, MAX>> for i128
              where the constant `MIN` has type `i128`, the constant `MAX` has type `i128`;
help: try using a fully qualified path to specify the expected types
    |
252 |                 if value < 0 || value > <u64 as Into<T>>::into(u64::max_value()) {
    |                                         +++++++++++++++++++++++                ~

error[E0283]: type annotations needed
   --> src/stream/binary_reader.rs:252:58
    |
252 |                 if value < 0 || value > u64::max_value().into() {
    |                                                          ^^^^
    |
note: multiple `impl`s satisfying `_: From<u64>` found
   --> src/integer.rs:91:1
    |
91  | impl From<u64> for Integer {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/value.rs:552:1
    |
552 | impl From<u64> for Value {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and more `impl`s found in the following crates: `core`:
            - impl From<u64> for AtomicU64;
            - impl From<u64> for i128;
            - impl From<u64> for u128;
    = note: required for `u64` to implement `Into<_>`
help: try using a fully qualified path to specify the expected types
    |
252 |                 if value < 0 || value > <u64 as Into<T>>::into(u64::max_value()) {
    |                                         +++++++++++++++++++++++                ~

For more information about this error, try `rustc --explain E0283`.
error: could not compile `plist` (lib) due to 2 previous errors
```