### PR TITLE
bump quick-xml from 0.37.4 to 0.38.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 base64 = "0.22.0"
 time = { version = "0.3.30", features = ["parsing", "formatting"] }
 indexmap = "2.1.0"
-quick_xml = { package = "quick-xml", version = "0.37.4" }
+quick_xml = { package = "quick-xml", version = "0.38.0" }
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
 use std::{error, fmt, io};
+use quick_xml::escape::EscapeError;
+use quick_xml::encoding::EncodingError;
 
 #[cfg(feature = "serde")]
 use crate::stream::Event;
@@ -190,6 +192,18 @@ impl ErrorKind {
 impl From<InvalidXmlDate> for ErrorKind {
     fn from(_: InvalidXmlDate) -> Self {
         ErrorKind::InvalidDateString
+    }
+}
+
+impl From<EscapeError> for ErrorKind {
+    fn from(_: EscapeError) -> Self {
+        ErrorKind::InvalidXmlUtf8
+    }
+}
+
+impl From<EncodingError> for ErrorKind {
+    fn from(_: EncodingError) -> Self {
+        ErrorKind::InvalidXmlUtf8
     }
 }
 

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -274,6 +274,8 @@ mod tests {
             Boolean(true),
             String("IsNotFalse".into()),
             Boolean(false),
+            String("Pets".into()),
+            String("A cat & a dog.".into()),
             EndCollection,
         ];
 

--- a/tests/data/xml.plist
+++ b/tests/data/xml.plist
@@ -32,5 +32,7 @@
     <true/>
     <key>IsNotFalse</key>
     <false/>
+	<key>Pets</key>
+    <string>A cat &amp; a dog.</string>
 </dict>
 </plist>

--- a/tests/data/xml.plist
+++ b/tests/data/xml.plist
@@ -2,37 +2,37 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Author</key>
-    <string>William Shakespeare</string>
-    <key>Lines</key>
-    <array>
-        <string>It is a tale told by an idiot,     </string>
-        <string>Full of sound and fury, signifying nothing.</string>
-    </array>
-    <key>Death</key>
-    <integer>1564</integer>
-    <key>Height</key>
-    <real>1.6</real>
-    <key>Data</key>
-    <data>
-        AAAAvgAAAA
-        MAAAAeAAAA
-    </data>
-    <key>Birthdate</key>
-    <date>1981-05-16T11:32:06Z</date>
-    <key>Blank</key>
-    <string></string>
-    <key>BiggestNumber</key>
-    <integer>18446744073709551615</integer>
-    <key>SmallestNumber</key>
-    <integer>-9223372036854775808</integer>
-    <key>HexademicalNumber</key>
-    <integer>0xDEADBEEF</integer>
-    <key>IsTrue</key>
-    <true/>
-    <key>IsNotFalse</key>
-    <false/>
-    <key>Pets</key>
-    <string>A cat &amp; a dog.</string>
+	<key>Author</key>
+	<string>William Shakespeare</string>
+	<key>Lines</key>
+	<array>
+		<string>It is a tale told by an idiot,     </string>
+		<string>Full of sound and fury, signifying nothing.</string>
+	</array>
+	<key>Death</key>
+	<integer>1564</integer>
+	<key>Height</key>
+	<real>1.6</real>
+	<key>Data</key>
+	<data>
+		AAAAvgAAAA
+		MAAAAeAAAA
+	</data>
+	<key>Birthdate</key>
+	<date>1981-05-16T11:32:06Z</date>
+	<key>Blank</key>
+	<string></string>
+	<key>BiggestNumber</key>
+	<integer>18446744073709551615</integer>
+	<key>SmallestNumber</key>
+	<integer>-9223372036854775808</integer>
+	<key>HexademicalNumber</key>
+	<integer>0xDEADBEEF</integer>
+	<key>IsTrue</key>
+	<true/>
+	<key>IsNotFalse</key>
+	<false/>
+	<key>Pets</key>
+	<string>A cat &amp; a dog.</string>
 </dict>
 </plist>

--- a/tests/data/xml.plist
+++ b/tests/data/xml.plist
@@ -2,26 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Author</key>
-	<string>William Shakespeare</string>
-	<key>Lines</key>
-	<array>
-		<string>It is a tale told by an idiot,     </string>
-		<string>Full of sound and fury, signifying nothing.</string>
-	</array>
-	<key>Death</key>
-	<integer>1564</integer>
-	<key>Height</key>
-	<real>1.6</real>
-	<key>Data</key>
-	<data>
-		AAAAvgAAAA
-		MAAAAeAAAA
-	</data>
-	<key>Birthdate</key>
-	<date>1981-05-16T11:32:06Z</date>
-	<key>Blank</key>
-	<string></string>
+    <key>Author</key>
+    <string>William Shakespeare</string>
+    <key>Lines</key>
+    <array>
+        <string>It is a tale told by an idiot,     </string>
+        <string>Full of sound and fury, signifying nothing.</string>
+    </array>
+    <key>Death</key>
+    <integer>1564</integer>
+    <key>Height</key>
+    <real>1.6</real>
+    <key>Data</key>
+    <data>
+        AAAAvgAAAA
+        MAAAAeAAAA
+    </data>
+    <key>Birthdate</key>
+    <date>1981-05-16T11:32:06Z</date>
+    <key>Blank</key>
+    <string></string>
     <key>BiggestNumber</key>
     <integer>18446744073709551615</integer>
     <key>SmallestNumber</key>
@@ -32,7 +32,7 @@
     <true/>
     <key>IsNotFalse</key>
     <false/>
-	<key>Pets</key>
+    <key>Pets</key>
     <string>A cat &amp; a dog.</string>
 </dict>
 </plist>

--- a/tests/data/xml_entity_error.plist
+++ b/tests/data/xml_entity_error.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+&#32;&amp;
+<!-- &#32; is allowed, as it is a whitespace, but &amp; is not, so we expect to fail at position 174, not 169 -->
+</plist>


### PR DESCRIPTION
The `unescape` method got removed and `decode` is now used, entities are surfaced as their own new event type `GeneralRef`, containing the decoded character.