### PR TITLE
address clippy lints

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -117,7 +117,7 @@ pub mod serde_impls {
 
     struct DataVisitor;
 
-    impl<'de> de::Visitor<'de> for DataVisitor {
+    impl de::Visitor<'_> for DataVisitor {
         type Value = Data;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/date.rs
+++ b/src/date.rs
@@ -157,7 +157,7 @@ pub mod serde_impls {
 
     struct DateStrVisitor;
 
-    impl<'de> Visitor<'de> for DateStrVisitor {
+    impl Visitor<'_> for DateStrVisitor {
         type Value = Date;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/de.rs
+++ b/src/de.rs
@@ -103,7 +103,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::Deserializer<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::Deserializer<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {
@@ -268,7 +268,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::EnumAccess<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::EnumAccess<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {
@@ -283,7 +283,7 @@ where
     }
 }
 
-impl<'de, 'a, 'event, I> de::VariantAccess<'de> for &'a mut Deserializer<'event, I>
+impl<'de, 'event, I> de::VariantAccess<'de> for &mut Deserializer<'event, I>
 where
     I: IntoIterator<Item = Result<Event<'event>, Error>>,
 {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,4 +1,4 @@
-//! A map of String to `plist::Value`.
+//! A map of `String` to ``plist::Value``.
 //!
 //! The map is currently backed by an [`IndexMap`]. This may be changed in a future minor release.
 //!

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,4 +1,4 @@
-//! A map of `String` to ``plist::Value``.
+//! A map of `String` to `plist::Value`.
 //!
 //! The map is currently backed by an [`IndexMap`]. This may be changed in a future minor release.
 //!

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,4 +1,4 @@
-//! A map of String to plist::Value.
+//! A map of String to `plist::Value`.
 //!
 //! The map is currently backed by an [`IndexMap`]. This may be changed in a future minor release.
 //!
@@ -30,7 +30,7 @@ impl Dictionary {
     /// Clears the dictionary, removing all values.
     #[inline]
     pub fn clear(&mut self) {
-        self.map.clear()
+        self.map.clear();
     }
 
     /// Returns a reference to the value corresponding to the key.
@@ -76,7 +76,7 @@ impl Dictionary {
     where
         F: FnMut(&String, &mut Value) -> bool,
     {
-        self.map.retain(keep)
+        self.map.retain(keep);
     }
 
     /// Sort the dictionary keys.
@@ -87,7 +87,7 @@ impl Dictionary {
     /// ensure a consistent key order.
     #[inline]
     pub fn sort_keys(&mut self) {
-        self.map.sort_keys()
+        self.map.sort_keys();
     }
 
     /// Gets the given key's corresponding entry in the dictionary for in-place manipulation.
@@ -175,7 +175,7 @@ impl Dictionary {
 /// }
 /// # ;
 /// ```
-impl<'a> ops::Index<&'a str> for Dictionary {
+impl ops::Index<&str> for Dictionary {
     type Output = Value;
 
     fn index(&self, index: &str) -> &Value {
@@ -192,7 +192,7 @@ impl<'a> ops::Index<&'a str> for Dictionary {
 /// #
 /// dict["key"] = "value".into();
 /// ```
-impl<'a> ops::IndexMut<&'a str> for Dictionary {
+impl ops::IndexMut<&str> for Dictionary {
     fn index_mut(&mut self, index: &str) -> &mut Value {
         self.map.get_mut(index).expect("no entry found for key")
     }
@@ -556,7 +556,7 @@ impl<'a> IntoIterator for &'a Dictionary {
     }
 }
 
-/// An iterator over a plist::Dictionary's entries.
+/// An iterator over a `plist::Dictionary`'s entries.
 pub struct Iter<'a> {
     iter: IterImpl<'a>,
 }
@@ -578,7 +578,7 @@ impl<'a> IntoIterator for &'a mut Dictionary {
     }
 }
 
-/// A mutable iterator over a plist::Dictionary's entries.
+/// A mutable iterator over a `plist::Dictionary`'s entries.
 pub struct IterMut<'a> {
     iter: map::IterMut<'a, String, Value>,
 }
@@ -598,7 +598,7 @@ impl IntoIterator for Dictionary {
     }
 }
 
-/// An owning iterator over a plist::Dictionary's entries.
+/// An owning iterator over a `plist::Dictionary`'s entries.
 pub struct IntoIter {
     iter: map::IntoIter<String, Value>,
 }
@@ -607,7 +607,7 @@ delegate_iterator!((IntoIter) => (String, Value));
 
 //////////////////////////////////////////////////////////////////////////////
 
-/// An iterator over a plist::Dictionary's keys.
+/// An iterator over a `plist::Dictionary`'s keys.
 pub struct Keys<'a> {
     iter: map::Keys<'a, String, Value>,
 }
@@ -616,7 +616,7 @@ delegate_iterator!((Keys<'a>) => &'a String);
 
 //////////////////////////////////////////////////////////////////////////////
 
-/// An iterator over a plist::Dictionary's values.
+/// An iterator over a `plist::Dictionary`'s values.
 pub struct Values<'a> {
     iter: map::Values<'a, String, Value>,
 }
@@ -625,7 +625,7 @@ delegate_iterator!((Values<'a>) => &'a Value);
 
 //////////////////////////////////////////////////////////////////////////////
 
-/// A mutable iterator over a plist::Dictionary's values.
+/// A mutable iterator over a `plist::Dictionary`'s values.
 pub struct ValuesMut<'a> {
     iter: map::ValuesMut<'a, String, Value>,
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -9,21 +9,12 @@ pub struct Integer {
 impl Integer {
     /// Returns the value as an `i64` if it can be represented by that type.
     pub fn as_signed(self) -> Option<i64> {
-        if self.value >= i128::from(i64::min_value()) && self.value <= i128::from(i64::max_value())
-        {
-            Some(self.value as i64)
-        } else {
-            None
-        }
+        i64::try_from(self.value).ok()
     }
 
     /// Returns the value as a `u64` if it can be represented by that type.
     pub fn as_unsigned(self) -> Option<u64> {
-        if self.value >= 0 && self.value <= i128::from(u64::max_value()) {
-            Some(self.value as u64)
-        } else {
-            None
-        }
+        u64::try_from(self.value).ok()
     }
 
     pub(crate) fn from_str(s: &str) -> Result<Self, ParseIntError> {
@@ -147,7 +138,7 @@ pub mod serde_impls {
 
     struct IntegerVisitor;
 
-    impl<'de> Visitor<'de> for IntegerVisitor {
+    impl Visitor<'_> for IntegerVisitor {
         type Value = Integer;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,5 @@ extern crate serde_derive;
 mod serde_tests;
 
 fn u64_to_usize(len_u64: u64) -> Option<usize> {
-    let len = len_u64 as usize;
-    if len as u64 != len_u64 {
-        return None; // Too long
-    }
-    Some(len)
+    usize::try_from(len_u64).ok()
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -326,13 +326,13 @@ struct DateSerializer<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> DateSerializer<'a, W> {
-    fn expecting_date_error(&self) -> Error {
+impl<W: Writer> DateSerializer<'_, W> {
+    fn expecting_date_error() -> Error {
         ser::Error::custom("plist date string expected")
     }
 }
 
-impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
+impl<W: Writer> ser::Serializer for DateSerializer<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -345,80 +345,80 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
     type SerializeStructVariant = ser::Impossible<(), Error>;
 
     fn serialize_bool(self, _: bool) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_i8(self, _: i8) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_i16(self, _: i16) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_i32(self, _: i32) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_i64(self, _: i64) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_u8(self, _: u8) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_u16(self, _: u16) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_u32(self, _: u32) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_u64(self, _: u64) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_f32(self, _: f32) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_f64(self, _: f64) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_char(self, _: char) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_str(self, v: &str) -> Result<(), Error> {
-        let date = Date::from_xml_format(v).map_err(|_| self.expecting_date_error())?;
+        let date = Date::from_xml_format(v).map_err(|_| Self::expecting_date_error())?;
         self.ser.write_date(date)
     }
 
     fn serialize_bytes(self, _: &[u8]) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_none(self) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_some<T: ?Sized + ser::Serialize>(self, _: &T) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_unit(self) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
@@ -426,7 +426,7 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
         _: &'static str,
         _: &T,
     ) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
@@ -436,15 +436,15 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
         _: &'static str,
         _: &T,
     ) -> Result<(), Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_tuple_struct(
@@ -452,7 +452,7 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeTupleStruct, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_tuple_variant(
@@ -462,15 +462,15 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeTupleVariant, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 
     fn serialize_struct_variant(
@@ -480,7 +480,7 @@ impl<'a, W: Writer> ser::Serializer for DateSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeStructVariant, Error> {
-        Err(self.expecting_date_error())
+        Err(Self::expecting_date_error())
     }
 }
 
@@ -488,13 +488,13 @@ struct UidSerializer<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> UidSerializer<'a, W> {
-    fn expecting_uid_error(&self) -> Error {
+impl<W: Writer> UidSerializer<'_, W> {
+    fn expecting_uid_error() -> Error {
         ser::Error::custom("plist uid expected")
     }
 }
 
-impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
+impl<W: Writer> ser::Serializer for UidSerializer<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -507,35 +507,35 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
     type SerializeStructVariant = ser::Impossible<(), Error>;
 
     fn serialize_bool(self, _: bool) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_i8(self, _: i8) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_i16(self, _: i16) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_i32(self, _: i32) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_i64(self, _: i64) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_u8(self, _: u8) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_u16(self, _: u16) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_u32(self, _: u32) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_u64(self, v: u64) -> Result<(), Error> {
@@ -543,43 +543,43 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
     }
 
     fn serialize_f32(self, _: f32) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_f64(self, _: f64) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_char(self, _: char) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_str(self, _: &str) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_bytes(self, _: &[u8]) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_none(self) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_some<T: ?Sized + ser::Serialize>(self, _: &T) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_unit(self) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_unit_struct(self, _: &'static str) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
@@ -587,7 +587,7 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
         _: &'static str,
         _: &T,
     ) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
@@ -597,15 +597,15 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
         _: &'static str,
         _: &T,
     ) -> Result<(), Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_tuple_struct(
@@ -613,7 +613,7 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeTupleStruct, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_tuple_variant(
@@ -623,15 +623,15 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeTupleVariant, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 
     fn serialize_struct_variant(
@@ -641,7 +641,7 @@ impl<'a, W: Writer> ser::Serializer for UidSerializer<'a, W> {
         _: &'static str,
         _: usize,
     ) -> Result<Self::SerializeStructVariant, Error> {
-        Err(self.expecting_uid_error())
+        Err(Self::expecting_uid_error())
     }
 }
 
@@ -650,7 +650,7 @@ pub struct Compound<'a, W: 'a + Writer> {
     ser: &'a mut Serializer<W>,
 }
 
-impl<'a, W: Writer> ser::SerializeSeq for Compound<'a, W> {
+impl<W: Writer> ser::SerializeSeq for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -664,7 +664,7 @@ impl<'a, W: Writer> ser::SerializeSeq for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTuple for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTuple for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -678,7 +678,7 @@ impl<'a, W: Writer> ser::SerializeTuple for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTupleStruct for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTupleStruct for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -692,7 +692,7 @@ impl<'a, W: Writer> ser::SerializeTupleStruct for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeTupleVariant for Compound<'a, W> {
+impl<W: Writer> ser::SerializeTupleVariant for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -707,7 +707,7 @@ impl<'a, W: Writer> ser::SerializeTupleVariant for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeMap for Compound<'a, W> {
+impl<W: Writer> ser::SerializeMap for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -726,7 +726,7 @@ impl<'a, W: Writer> ser::SerializeMap for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeStruct for Compound<'a, W> {
+impl<W: Writer> ser::SerializeStruct for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 
@@ -746,7 +746,7 @@ impl<'a, W: Writer> ser::SerializeStruct for Compound<'a, W> {
     }
 }
 
-impl<'a, W: Writer> ser::SerializeStructVariant for Compound<'a, W> {
+impl<W: Writer> ser::SerializeStructVariant for Compound<'_, W> {
     type Ok = ();
     type Error = Error;
 

--- a/src/stream/ascii_reader.rs
+++ b/src/stream/ascii_reader.rs
@@ -328,7 +328,7 @@ impl<R: Read> Iterator for AsciiReader<R> {
     }
 }
 
-/// Maps `NextStep` encoding to Unicode, see:
+/// Maps NeXTSTEP encoding to Unicode, see:
 /// - <https://github.com/fonttools/openstep-plist/blob/master/src/openstep_plist/parser.pyx#L87-L106>
 /// - <ftp://ftp.unicode.org/Public/MAPPINGS/VENDORS/NEXT/NEXTSTEP.TXT>
 fn map_next_step_to_unicode(c: char) -> char {

--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -59,7 +59,7 @@ impl<R: Read> Read for PosReader<R> {
         let count = self.reader.read(buf)?;
         self.pos
             .checked_add(count as u64)
-            .expect("file cannot be larger than `u64::max_value()` bytes");
+            .expect("file cannot be larger than `u64::MAX` bytes");
         Ok(count)
     }
 }
@@ -249,10 +249,11 @@ impl<R: Read + Seek> BinaryReader<R> {
             (0x1, 3) => Some(Event::Integer(self.read_be_i64()?.into())),
             (0x1, 4) => {
                 let value = self.read_be_i128()?;
-                if value < 0 || value > i128::from(u64::max_value()) {
+                if let Ok(value) = u64::try_from(value) {
+                    Some(Event::Integer(value.into()))
+                } else {
                     return Err(self.with_pos(ErrorKind::IntegerOutOfRange));
                 }
-                Some(Event::Integer((value as u64).into()))
             }
             (0x1, _) => return Err(self.with_pos(ErrorKind::UnknownObjectType(token))), // variable length int
             (0x2, 2) => Some(Event::Real(f32::from_bits(self.read_be_u32()?).into())),

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -207,6 +207,8 @@ impl<'a> Iterator for Events<'a> {
         }
 
         Some(match self.stack.pop()? {
+            StackItem::Root(value)
+            | StackItem::DictValue(value) => handle_value(value, &mut self.stack),
             StackItem::Array(mut array) => {
                 if let Some(value) = array.next() {
                     // There might still be more items in the array so return it to the stack.
@@ -228,7 +230,6 @@ impl<'a> Iterator for Events<'a> {
                     Event::EndCollection
                 }
             }
-            StackItem::DictValue(value) | StackItem::Root(value) => handle_value(value, &mut self.stack),
         })
     }
 }

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -74,7 +74,6 @@ impl From<XmlReaderError> for ErrorKind {
                 Err(err) => ErrorKind::Io(std::io::Error::from(err.kind())),
             },
             XmlReaderError::Syntax(_) => ErrorKind::UnexpectedEof,
-            XmlReaderError::IllFormed(_) => ErrorKind::InvalidXmlSyntax,
             XmlReaderError::Encoding(_) => ErrorKind::InvalidXmlUtf8,
             _ => ErrorKind::InvalidXmlSyntax,
         }
@@ -115,7 +114,7 @@ impl<R: BufRead> Iterator for XmlReader<R> {
 impl<R: BufRead> ReaderState<R> {
     fn xml_reader_pos(&self) -> FilePosition {
         let pos = self.0.buffer_position();
-        FilePosition(pos as u64)
+        FilePosition(pos)
     }
 
     fn with_pos(&self, kind: ErrorKind) -> Error {
@@ -139,7 +138,7 @@ impl<R: BufRead> ReaderState<R> {
                         .map_err(|_| self.with_pos(ErrorKind::InvalidUtf8String));
                 }
                 XmlEvent::End(_) => {
-                    return Ok("".to_owned());
+                    return Ok(String::new());
                 }
                 XmlEvent::Eof => return Err(self.with_pos(ErrorKind::UnclosedXmlElement)),
                 XmlEvent::Start(_) => return Err(self.with_pos(ErrorKind::UnexpectedXmlOpeningTag)),

--- a/src/stream/xml_reader.rs
+++ b/src/stream/xml_reader.rs
@@ -59,8 +59,13 @@ impl From<XmlReaderError> for ErrorKind {
                 Err(err) => ErrorKind::Io(std::io::Error::from(err.kind())),
             },
             XmlReaderError::Syntax(_) => ErrorKind::UnexpectedEof,
+            XmlReaderError::IllFormed(_)
+            | XmlReaderError::InvalidAttr(_)
+            | XmlReaderError::Escape(_)
+            | XmlReaderError::Namespace(_) => {
+                ErrorKind::InvalidXmlSyntax
+            },
             XmlReaderError::Encoding(_) => ErrorKind::InvalidXmlUtf8,
-            _ => ErrorKind::InvalidXmlSyntax,
         }
     }
 }

--- a/src/stream/xml_writer.rs
+++ b/src/stream/xml_writer.rs
@@ -209,7 +209,7 @@ impl<W: Write> Writer for XmlWriter<W> {
                     return Ok(());
                 }
                 _ => {}
-            };
+            }
             match (this.stack.pop(), this.expecting_key) {
                 (Some(Element::Dictionary), true) => {
                     this.end_element("dict")?;
@@ -334,7 +334,7 @@ fn write_data_base64(
     for (i, line) in data.chunks(DATA_MAX_LINE_BYTES).enumerate() {
         // Write newline
         if write_initial_newline || i > 0 {
-            writer.write_all(&[b'\n'])?;
+            writer.write_all(b"\n")?;
         }
 
         // Write indent

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -71,7 +71,7 @@ pub mod serde_impls {
 
     struct UidU64Visitor;
 
-    impl<'de> Visitor<'de> for UidU64Visitor {
+    impl Visitor<'_> for UidU64Visitor {
         type Value = Uid;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/value.rs
+++ b/src/value.rs
@@ -683,7 +683,7 @@ impl Builder {
                 self.stack.push(StackItem::Array(array));
             }
             (Some(StackItem::Dict(dict)), Value::String(key)) => {
-                self.stack.push(StackItem::DictAndKey(dict, key))
+                self.stack.push(StackItem::DictAndKey(dict, key));
             }
             (Some(StackItem::Dict(_)), value) => {
                 return Err(ErrorKind::UnexpectedEventType {
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(Value::Integer(1.into()).as_unsigned_integer(), Some(1));
         assert_eq!(Value::Integer((-1).into()).as_unsigned_integer(), None);
         assert_eq!(
-            Value::Integer((i64::max_value() as u64 + 1).into()).as_signed_integer(),
+            Value::Integer((i64::MAX as u64 + 1).into()).as_signed_integer(),
             None
         );
         assert_eq!(Value::String("2".to_owned()).as_string(), Some("2"));


### PR DESCRIPTION
This addresses almost all regular clippy lints and some of the pedantic ones.

I left this one alone, as I personally don't find it more readable nor does it look very efficient:
```
error: manual `!RangeInclusive::contains` implementation
   --> src/stream/ascii_reader.rs:361:8
    |
361 |     if index < 128 || index > 0xff {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!(128..=0xff).contains(&index)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
```