### PR TITLE
Fail deserialisation if input is not completely consumed

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -424,27 +424,40 @@ pub fn from_file<P: AsRef<Path>, T: de::DeserializeOwned>(path: P) -> Result<T, 
 /// Deserializes an instance of type `T` from a seekable byte stream containing a plist of any encoding.
 pub fn from_reader<R: Read + Seek, T: de::DeserializeOwned>(reader: R) -> Result<T, Error> {
     let reader = stream::Reader::new(reader);
-    let mut de = Deserializer::new(reader);
-    de::Deserialize::deserialize(&mut de)
+    from_stream(reader)
 }
 
 /// Deserializes an instance of type `T` from a byte stream containing an ASCII encoded plist.
 pub fn from_reader_ascii<R: Read, T: de::DeserializeOwned>(reader: R) -> Result<T, Error> {
     let reader = stream::AsciiReader::new(reader);
-    let mut de = Deserializer::new(reader);
-    de::Deserialize::deserialize(&mut de)
+    from_stream(reader)
 }
 
 /// Deserializes an instance of type `T` from a byte stream containing an XML encoded plist.
 pub fn from_reader_xml<R: Read, T: de::DeserializeOwned>(reader: R) -> Result<T, Error> {
     let reader = stream::XmlReader::new(BufReader::new(reader));
-    let mut de = Deserializer::new(reader);
-    de::Deserialize::deserialize(&mut de)
+    from_stream(reader)
 }
 
 /// Interprets a [`Value`] as an instance of type `T`.
 pub fn from_value<T: de::DeserializeOwned>(value: &Value) -> Result<T, Error> {
     let events = value.events().map(Ok);
-    let mut de = Deserializer::new(events);
-    de::Deserialize::deserialize(&mut de)
+    from_stream(events)
+}
+
+pub(crate) fn from_stream<'event, T: de::DeserializeOwned>(
+    stream: impl IntoIterator<Item = Result<Event<'event>, Error>>,
+) -> Result<T, Error> {
+    let mut de = Deserializer::new(stream);
+    let value = de::Deserialize::deserialize(&mut de)?;
+
+    // TODO: Ideally this check would be inside the `Deserializer` implementation.
+    if let Some(event) = de.events.next().transpose()? {
+        return Err(ErrorKind::ExpectedEndOfEventStream {
+            found: EventKind::of_event(&event),
+        }
+        .without_position());
+    }
+
+    Ok(value)
 }

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -1038,3 +1038,12 @@ fn serialize_to_from_value() {
 
     assert_eq!(dog_roundtrip, dog);
 }
+
+#[test]
+fn deserialize_with_trailing_events_fails() {
+    let events = [Event::String("Foo".into()), Event::String("Bar".into())];
+
+    let value = crate::de::from_stream::<Value>(events.map(Ok));
+
+    assert!(value.is_err());
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -857,4 +857,13 @@ mod tests {
 
         assert_eq!(value.unwrap(), Value::Dictionary(dict));
     }
+
+    #[test]
+    fn builder_fails_if_all_events_have_not_been_read() {
+        let events = vec![String("Item 1".into()), String("Item 2".into())];
+
+        let value = Builder::build(events.into_iter().map(Ok));
+
+        assert!(value.is_err());
+    }
 }


### PR DESCRIPTION
The direct constructors for `Value` already perform this check.

I believe this should not cause problems with existing code as the only
XML and ASCII plists could be malformed in this way, and it would be
unlikely to find an XML plist with two children inside the root
`<plist>` element.

Closes #149