### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 
 [dependencies]
 base64 = "0.22.0"
-time = { version = "0.3.30", features = ["parsing", "formatting"] }
+time = { version = "0.3.47", features = ["parsing", "formatting"] }
 indexmap = "2.1.0"
 quick_xml = { package = "quick-xml", version = "0.38.0" }
 serde = { version = "1.0.2", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)