### PR TITLE
replace serde_yaml 0.9 to yaml_serde 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0.2" }
-serde_yaml = "0.8.21"
+yaml_serde = "0.10.3"

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -997,7 +997,7 @@ fn empty_array_and_dictionary_serialize_to_xml() {
 
 #[test]
 fn serde_yaml_to_value() {
-    let value: Value = serde_yaml::from_str("true").unwrap();
+    let value: Value = yaml_serde::from_str("true").unwrap();
     assert_eq!(value, Value::Boolean(true));
 }
 


### PR DESCRIPTION
Now yaml organization forked serde_yaml and officially supports this new yaml_serde.

[https://yaml.org/](https://yaml.org/) have link to
[https://yaml.com/](https://yaml.com/) on main page link to
[https://yaml.com/projects/yaml-serde/](https://yaml.com/projects/yaml-serde/)
and then it links to [https://github.com/yaml/yaml-serde](https://github.com/yaml/yaml-serde)
which is now part of the yaml project [https://github.com/yaml/]( https://github.com/yaml/)
So we should use this new crate [https://crates.io/crates/yaml_serde](https://crates.io/crates/yaml_serde)

## Motivation
[Deprecation notice](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34)
[serde_yaml ](https://crates.io/crates/serde_yaml) is deprecated
v0.9.34+deprecated

## Solution
Replace with  actively supported [yaml_serde](https://crates.io/crates/yaml_serde)
by official yaml-project which is a fork of original lib.
