### PR TITLE
`plist!` macro (revival)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         env:
           TOOLCHAIN: ${{ matrix.channel }}-${{ matrix.target }}
 
+      - name: Install cargo-expand
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand@1
+
       - name: Build and Test (Debug, No Default Features)
         run: cargo test --locked --no-default-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: cargo test --locked --all-features -Z minimal-versions
 
       - name: Test macro expansion
-        if: matrix.channel == "1.88.0"
+        if: matrix.channel == '1.88.0'
         run: cargo test macro_expansion -- --ignored
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            # MSRV. If updating this, also update below for "Test macro
+            # expansion" step
             channel: 1.88.0
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -61,6 +63,10 @@ jobs:
       - name: Build and Test (Minimal Versions, All Features)
         if: matrix.channel == 'nightly'
         run: cargo test --locked --all-features -Z minimal-versions
+
+      - name: Test macro expansion
+        if: matrix.channel == "1.88.0"
+        run: cargo test macro_expansion -- --ignored
 
   lint:
     name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -37,9 +61,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
@@ -53,12 +77,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -72,6 +96,23 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "macrotest"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd198afd908012e57564b66e43e7d4d19056cec7e6232e9e6d54a1798622f81d"
+dependencies = [
+ "diff",
+ "fastrand",
+ "glob",
+ "prettyplease",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn",
+ "toml",
+]
 
 [[package]]
 name = "memchr"
@@ -90,12 +131,14 @@ name = "plist"
 version = "1.9.0"
 dependencies = [
  "base64",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
+ "macrotest",
  "quick-xml",
  "serde",
  "serde_derive",
  "serde_yaml",
  "time",
+ "trybuild",
 ]
 
 [[package]]
@@ -103,6 +146,16 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -167,6 +220,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +262,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -221,10 +311,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "dissimilar",
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "yaml-rust"
@@ -234,3 +409,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ serde = { version = "1.0.2", optional = true }
 [dev-dependencies]
 serde_derive = { version = "1.0.2" }
 serde_yaml = "0.8.21"
+trybuild = { version = "1.0.81", features = ["diff"] }
+macrotest = "1.0.12"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ serde = { version = "1.0.2", optional = true }
 [dev-dependencies]
 serde_derive = { version = "1.0.2" }
 serde_yaml = "0.8.21"
-trybuild = { version = "1.0.81", features = ["diff"] }
-macrotest = "1.0.12"
+trybuild = { version = "1.0.116", features = ["diff"] }
+macrotest = "1.2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,6 @@ mod error;
 mod integer;
 mod uid;
 mod value;
-#[macro_use]
-#[cfg(feature = "serde")]
 mod macros;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ mod error;
 mod integer;
 mod uid;
 mod value;
+#[macro_use]
+#[cfg(feature = "serde")]
 mod macros;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ mod error;
 mod integer;
 mod uid;
 mod value;
+mod macros;
 
 #[cfg(feature = "serde")]
 pub use data::Data;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,303 @@
+/// Construct a `plist::Value` from a JSON literal.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let value = plist!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///         "features": [
+///             "serde",
+///         ],
+///         "homepage": null
+///     }
+/// });
+/// ```
+///
+/// Variables or expressions can be interpolated into the PList literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into a object key must
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `plist!` macro will panic.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let code = 200;
+/// let features = vec!["serde", "plist"];
+///
+/// let value = plist!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         features[0]: features[1]
+///     }
+/// });
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```
+/// # use plist::plist;
+/// #
+/// let value = plist!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! plist {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($plist:tt)+) => {
+        plist_internal!($($plist)+)
+    };
+}
+
+// Rocket relies on this because they export their own `plist!` with a different
+// doc comment than ours, and various Rust bugs prevent them from calling our
+// `plist!` from their `plist!` so they call `plist_internal!` directly. Check with
+// @SergioBenitez before making breaking changes to this macro.
+//
+// Changes are fine as long as `plist_internal!` does not call any new helper
+// macros and can still be invoked as `plist_internal!($($plist)+)`.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! plist_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: plist_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        plist_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        plist_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)* plist_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        plist_internal!(@array [$($elems,)* plist_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        plist_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        plist_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: plist_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        plist_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        plist_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        plist_internal!(@object $object [$($key)+] (plist_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        plist_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        plist_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        plist_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        plist_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        plist_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        plist_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: plist_internal!($($plist)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::Value::Null
+    };
+
+    (true) => {
+        $crate::Value::Bool(true)
+    };
+
+    (false) => {
+        $crate::Value::Bool(false)
+    };
+
+    ([]) => {
+        $crate::Value::Array(plist_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::Array(plist_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Value::Dictionary($crate::Dictionary::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::Dictionary({
+            let mut object = $crate::Dictionary::new();
+            plist_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::to_value(&$other).unwrap()
+    };
+}
+
+// The plist_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to plist::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! plist_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,8 +9,7 @@
 ///     "payload": {
 ///         "features": [
 ///             "serde",
-///         ],
-///         "homepage": null
+///         ]
 ///     }
 /// });
 /// ```
@@ -84,11 +83,6 @@ macro_rules! plist_internal {
         plist_internal_vec![$($elems),*]
     };
 
-    // Next element is `null`.
-    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
-        plist_internal!(@array [$($elems,)* plist_internal!(null)] $($rest)*)
-    };
-
     // Next element is `true`.
     (@array [$($elems:expr,)*] true $($rest:tt)*) => {
         plist_internal!(@array [$($elems,)* plist_internal!(true)] $($rest)*)
@@ -156,11 +150,6 @@ macro_rules! plist_internal {
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
         let _ = $object.insert(($($key)+).into(), $value);
-    };
-
-    // Next value is `null`.
-    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
-        plist_internal!(@object $object [$($key)+] (plist_internal!(null)) $($rest)*);
     };
 
     // Next value is `true`.
@@ -240,16 +229,12 @@ macro_rules! plist_internal {
     // Must be invoked as: plist_internal!($($plist)+)
     //////////////////////////////////////////////////////////////////////////
 
-    (null) => {
-        $crate::Value::Null
-    };
-
     (true) => {
-        $crate::Value::Bool(true)
+        $crate::Value::Boolean(true)
     };
 
     (false) => {
-        $crate::Value::Bool(false)
+        $crate::Value::Boolean(false)
     };
 
     ([]) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-/// Construct a `plist::Value` from a JSON-like literal.
+/// Constructs a `plist::Value` from a JSON-like literal.
 ///
 /// ```
 /// # use plist::plist;
@@ -54,13 +54,6 @@ macro_rules! plist {
     };
 }
 
-// Rocket relies on this because they export their own `plist!` with a different
-// doc comment than ours, and various Rust bugs prevent them from calling our
-// `plist!` from their `plist!` so they call `plist_internal!` directly. Check with
-// @SergioBenitez before making breaking changes to this macro.
-//
-// Changes are fine as long as `plist_internal!` does not call any new helper
-// macros and can still be invoked as `plist_internal!($($plist)+)`.
 #[macro_export(local_inner_macros)]
 #[doc(hidden)]
 macro_rules! plist_internal {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -257,10 +257,10 @@ macro_rules! plist_internal {
         })
     };
 
-    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Any Into<plist::Value> type: numbers, strings, struct literals, variables etc.
     // Must be below every other rule.
     ($other:expr) => {
-        $crate::to_value(&$other).unwrap()
+        $crate::Value::from($other)
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-/// Construct a `plist::Value` from a JSON literal.
+/// Construct a `plist::Value` from a JSON-like literal.
 ///
 /// ```
 /// # use plist::plist;
@@ -14,12 +14,10 @@
 /// });
 /// ```
 ///
-/// Variables or expressions can be interpolated into the PList literal. Any type
-/// interpolated into an array element or object value must implement Serde's
-/// `Serialize` trait, while any type interpolated into a object key must
-/// implement `Into<String>`. If the `Serialize` implementation of the
-/// interpolated type decides to fail, or if the interpolated type contains a
-/// map with non-string keys, the `plist!` macro will panic.
+/// Variables or expressions can be interpolated into the literal. Any type
+/// interpolated into an array element or object value must implement the
+/// `Into<Value>` trait, while any type interpolated into a object key must
+/// implement `Into<String>`.
 ///
 /// ```
 /// # use plist::plist;

--- a/tests/expand/dict.expanded.rs
+++ b/tests/expand/dict.expanded.rs
@@ -1,0 +1,35 @@
+use plist::plist;
+fn dict() {
+    ::plist::Value::Dictionary({
+        let mut object = ::plist::Dictionary::new();
+        let _ = object.insert(("a").into(), ::plist::Value::Boolean(true));
+        let _ = object.insert(("b").into(), ::plist::to_value(&"astring").unwrap());
+        let _ = object.insert(("c").into(), ::plist::to_value(&1).unwrap());
+        let _ = object.insert(("d").into(), ::plist::to_value(&1.0).unwrap());
+        let _ = object
+            .insert(
+                ("e").into(),
+                ::plist::Value::Array(
+                    <[_]>::into_vec(
+                        #[rustc_box]
+                        ::alloc::boxed::Box::new([
+                            ::plist::to_value(&1).unwrap(),
+                            ::plist::to_value(&2).unwrap(),
+                            ::plist::to_value(&3).unwrap(),
+                        ]),
+                    ),
+                ),
+            );
+        let _ = object
+            .insert(
+                ("f").into(),
+                ::plist::Value::Dictionary({
+                    let mut object = ::plist::Dictionary::new();
+                    let _ = object.insert(("a").into(), ::plist::to_value(&1).unwrap());
+                    let _ = object.insert(("b").into(), ::plist::to_value(&2).unwrap());
+                    object
+                }),
+            );
+        object
+    });
+}

--- a/tests/expand/dict.expanded.rs
+++ b/tests/expand/dict.expanded.rs
@@ -3,20 +3,22 @@ fn dict() {
     ::plist::Value::Dictionary({
         let mut object = ::plist::Dictionary::new();
         let _ = object.insert(("a").into(), ::plist::Value::Boolean(true));
-        let _ = object.insert(("b").into(), ::plist::to_value(&"astring").unwrap());
-        let _ = object.insert(("c").into(), ::plist::to_value(&1).unwrap());
-        let _ = object.insert(("d").into(), ::plist::to_value(&1.0).unwrap());
+        let _ = object.insert(("b").into(), ::plist::Value::from("astring"));
+        let _ = object.insert(("c").into(), ::plist::Value::from(1));
+        let _ = object.insert(("d").into(), ::plist::Value::from(1.0));
         let _ = object
             .insert(
                 ("e").into(),
                 ::plist::Value::Array(
-                    <[_]>::into_vec(
-                        #[rustc_box]
-                        ::alloc::boxed::Box::new([
-                            ::plist::to_value(&1).unwrap(),
-                            ::plist::to_value(&2).unwrap(),
-                            ::plist::to_value(&3).unwrap(),
-                        ]),
+                    ::alloc::boxed::box_assume_init_into_vec_unsafe(
+                        ::alloc::intrinsics::write_box_via_move(
+                            ::alloc::boxed::Box::new_uninit(),
+                            [
+                                ::plist::Value::from(1),
+                                ::plist::Value::from(2),
+                                ::plist::Value::from(3),
+                            ],
+                        ),
                     ),
                 ),
             );
@@ -25,8 +27,8 @@ fn dict() {
                 ("f").into(),
                 ::plist::Value::Dictionary({
                     let mut object = ::plist::Dictionary::new();
-                    let _ = object.insert(("a").into(), ::plist::to_value(&1).unwrap());
-                    let _ = object.insert(("b").into(), ::plist::to_value(&2).unwrap());
+                    let _ = object.insert(("a").into(), ::plist::Value::from(1));
+                    let _ = object.insert(("b").into(), ::plist::Value::from(2));
                     object
                 }),
             );

--- a/tests/expand/dict.expanded.rs
+++ b/tests/expand/dict.expanded.rs
@@ -10,15 +10,12 @@ fn dict() {
             .insert(
                 ("e").into(),
                 ::plist::Value::Array(
-                    ::alloc::boxed::box_assume_init_into_vec_unsafe(
-                        ::alloc::intrinsics::write_box_via_move(
-                            ::alloc::boxed::Box::new_uninit(),
-                            [
-                                ::plist::Value::from(1),
-                                ::plist::Value::from(2),
-                                ::plist::Value::from(3),
-                            ],
-                        ),
+                    <[_]>::into_vec(
+                        ::alloc::boxed::box_new([
+                            ::plist::Value::from(1),
+                            ::plist::Value::from(2),
+                            ::plist::Value::from(3),
+                        ]),
                     ),
                 ),
             );

--- a/tests/expand/dict.rs
+++ b/tests/expand/dict.rs
@@ -1,0 +1,12 @@
+use plist::plist;
+
+fn dict() {
+    plist!({
+        "a" : true,
+        "b" : "astring",
+        "c" : 1,
+        "d" : 1.0,
+        "e" : [1, 2, 3],
+        "f" : { "a" : 1, "b" : 2 },
+    });
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,11 @@
+#[cfg_attr(miri, ignore = "incompatible with miri")]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}
+
+#[test]
+pub fn pass() {
+    macrotest::expand("tests/expand/*.rs");
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -6,6 +6,7 @@ fn ui() {
 }
 
 #[test]
-pub fn pass() {
+#[ignore = "must be run on MSRV compiler"]
+pub fn macro_expansion() {
     macrotest::expand("tests/expand/*.rs");
 }

--- a/tests/ui/missing_colon.rs
+++ b/tests/ui/missing_colon.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" });
+}

--- a/tests/ui/missing_colon.stderr
+++ b/tests/ui/missing_colon.stderr
@@ -1,0 +1,12 @@
+error: unexpected end of macro invocation
+ --> tests/ui/missing_colon.rs:4:5
+  |
+4 |     plist!({ "a" });
+  |     ^^^^^^^^^^^^^^^ missing tokens in macro arguments
+  |
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `plist_internal` which comes from the expansion of the macro `plist` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_comma.rs
+++ b/tests/ui/missing_comma.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "1": "" "2": "" });
+}

--- a/tests/ui/missing_comma.stderr
+++ b/tests/ui/missing_comma.stderr
@@ -1,0 +1,13 @@
+error: no rules expected the token `"2"`
+ --> tests/ui/missing_comma.rs:4:22
+  |
+4 |     plist!({ "1": "" "2": "" });
+  |                     -^^^ no rules expected this token in macro call
+  |                     |
+  |                     help: missing comma here
+  |
+note: while trying to match `,`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |              ^

--- a/tests/ui/missing_comma.stderr
+++ b/tests/ui/missing_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `"2"`
+error: no rules expected `"2"`
  --> tests/ui/missing_comma.rs:4:22
   |
 4 |     plist!({ "1": "" "2": "" });

--- a/tests/ui/missing_value.rs
+++ b/tests/ui/missing_value.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : });
+}

--- a/tests/ui/missing_value.stderr
+++ b/tests/ui/missing_value.stderr
@@ -1,0 +1,12 @@
+error: unexpected end of macro invocation
+ --> tests/ui/missing_value.rs:4:5
+  |
+4 |     plist!({ "a" : });
+  |     ^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+  |
+note: while trying to match `@`
+ --> src/macros.rs
+  |
+  |     (@array [$($elems:expr,)*]) => {
+  |      ^
+  = note: this error originates in the macro `plist_internal` which comes from the expansion of the macro `plist` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/not_found.rs
+++ b/tests/ui/not_found.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : x });
+}

--- a/tests/ui/not_found.stderr
+++ b/tests/ui/not_found.stderr
@@ -1,0 +1,5 @@
+error[E0425]: cannot find value `x` in this scope
+ --> tests/ui/not_found.rs:4:20
+  |
+4 |     plist!({ "a" : x });
+  |                    ^ not found in this scope

--- a/tests/ui/parse_expr.rs
+++ b/tests/ui/parse_expr.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" : ~ });
+}

--- a/tests/ui/parse_expr.stderr
+++ b/tests/ui/parse_expr.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `~`
+ --> tests/ui/parse_expr.rs:4:20
+  |
+4 |     plist!({ "a" : ~ });
+  |                    ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$e:expr`
+ --> src/macros.rs
+  |
+  |     ($e:expr , $($tt:tt)*) => {};
+  |      ^^^^^^^

--- a/tests/ui/parse_expr.stderr
+++ b/tests/ui/parse_expr.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `~`
+error: no rules expected `~`
  --> tests/ui/parse_expr.rs:4:20
   |
 4 |     plist!({ "a" : ~ });

--- a/tests/ui/parse_key.rs
+++ b/tests/ui/parse_key.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "".s : true });
+}

--- a/tests/ui/parse_key.stderr
+++ b/tests/ui/parse_key.stderr
@@ -1,0 +1,5 @@
+error[E0609]: no field `s` on type `&'static str`
+ --> tests/ui/parse_key.rs:4:17
+  |
+4 |     plist!({ "".s : true });
+  |                 ^ unknown field

--- a/tests/ui/unexpected_after_array_element.rs
+++ b/tests/ui/unexpected_after_array_element.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!([ true => ]);
+}

--- a/tests/ui/unexpected_after_array_element.stderr
+++ b/tests/ui/unexpected_after_array_element.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `=>`
+ --> tests/ui/unexpected_after_array_element.rs:4:19
+  |
+4 |     plist!([ true => ]);
+  |                   ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_after_array_element.stderr
+++ b/tests/ui/unexpected_after_array_element.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `=>`
+error: no rules expected `=>`
  --> tests/ui/unexpected_after_array_element.rs:4:19
   |
 4 |     plist!([ true => ]);

--- a/tests/ui/unexpected_after_map_entry.rs
+++ b/tests/ui/unexpected_after_map_entry.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "k": true => });
+}

--- a/tests/ui/unexpected_after_map_entry.stderr
+++ b/tests/ui/unexpected_after_map_entry.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `=>`
+ --> tests/ui/unexpected_after_map_entry.rs:4:24
+  |
+4 |     plist!({ "k": true => });
+  |                        ^^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_after_map_entry.stderr
+++ b/tests/ui/unexpected_after_map_entry.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `=>`
+error: no rules expected `=>`
  --> tests/ui/unexpected_after_map_entry.rs:4:24
   |
 4 |     plist!({ "k": true => });

--- a/tests/ui/unexpected_colon.rs
+++ b/tests/ui/unexpected_colon.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ : true });
+}

--- a/tests/ui/unexpected_colon.stderr
+++ b/tests/ui/unexpected_colon.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `:`
+ --> tests/ui/unexpected_colon.rs:4:14
+  |
+4 |     plist!({ : true });
+  |              ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_colon.stderr
+++ b/tests/ui/unexpected_colon.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `:`
+error: no rules expected `:`
  --> tests/ui/unexpected_colon.rs:4:14
   |
 4 |     plist!({ : true });

--- a/tests/ui/unexpected_comma.rs
+++ b/tests/ui/unexpected_comma.rs
@@ -1,0 +1,5 @@
+use plist::plist;
+
+fn main() {
+    plist!({ "a" , "b": true });
+}

--- a/tests/ui/unexpected_comma.stderr
+++ b/tests/ui/unexpected_comma.stderr
@@ -1,0 +1,7 @@
+error: no rules expected the token `,`
+ --> tests/ui/unexpected_comma.rs:4:18
+  |
+4 |     plist!({ "a" , "b": true });
+  |                  ^ no rules expected this token in macro call
+  |
+  = note: while trying to match end of macro

--- a/tests/ui/unexpected_comma.stderr
+++ b/tests/ui/unexpected_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `,`
+error: no rules expected `,`
  --> tests/ui/unexpected_comma.rs:4:18
   |
 4 |     plist!({ "a" , "b": true });


### PR DESCRIPTION
This is a continuation of #143 with test expectations updated so they passed, and feedback addressed.

Full disclosure: I'm no more of an expert on the original `json!` macro than the average lay-person. We just use `rust-plist` a fair amount at my company and constructing `plist::Value`s by hand for test data and such can often be a painfully verbose exercise.

Also a big fan of the `plist_dict!` macro from #140, for what it's worth. I think both this macro and that one has value. `plist_array!` less so, since that can easily be built using this macro, but having the unwrapped `Dictionary` type is a nice convenience which the `plist!` macro can't produce. Would be happy to continue that PR if there's appetite for it.