### PR TITLE
Set default permissions for all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 
 name: CI
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+permissions:
+  contents: read
 
 jobs:
   build_and_test:


### PR DESCRIPTION
The default protocol for crates.io was changed to sparse in Rust v1.70.