### PR TITLE
fix: allow 3-byte reference size

### DIFF
--- a/src/stream/binary_reader.rs
+++ b/src/stream/binary_reader.rs
@@ -117,7 +117,7 @@ impl<R: Read + Seek> BinaryReader<R> {
 
         self.ref_size = self.read_u8()?;
         match self.ref_size {
-            1 | 2 | 4 | 8 => (),
+            1 | 2 | 3 | 4 | 8 => (),
             _ => return Err(self.with_pos(ErrorKind::InvalidTrailerObjectReferenceSize)),
         }
 


### PR DESCRIPTION
given that everything else already works with 3-byte/ 24-bit sizes the reader should allow 3-byte reference sizes too