### PR TITLE
Bump quick-xml to 0.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ enable_unstable_features_that_may_break_with_minor_version_bumps = []
 base64 = "0.22.0"
 time = { version = "0.3.47", features = ["parsing", "formatting"] }
 indexmap = "2.1.0"
-quick_xml = { package = "quick-xml", version = "0.39.2" }
+quick_xml = { package = "quick-xml", version = "0.41.0" }
 serde = { version = "1.0.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`quick-xml` 0.38–0.40 are affected by two RUSTSEC advisories, both fixed in 0.41.0:

- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) — quadratic-time duplicate-attribute check in `BytesStart::attributes()`.
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) — quadratic-time namespace resolution in `NsReader`.

`plist` doesn't use either affected path (it drives a plain `Reader` and never iterates attributes), so it isn't itself exploitable, but the transitive dependency still trips `cargo deny` for downstream users.

This is a pure version bump — `plist` builds and the full test suite passes against quick-xml 0.41.0 with no source changes.

Closes #190.